### PR TITLE
Implement specification corrections

### DIFF
--- a/specs/003-data-pipeline/003-00-package-structure/003-00-04-update-specs.md
+++ b/specs/003-data-pipeline/003-00-package-structure/003-00-04-update-specs.md
@@ -32,51 +32,51 @@
 
 ### パス参照更新
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/crawler/` への参照がある場合
       THEN `packages/pipeline/src/crawler/` に変更される
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/embedding/generate.ts` への参照がある場合
       THEN `packages/shared/src/embedding/generate.ts` に変更される（純粋ロジック）
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/embedding/batch-processor.ts` への参照がある場合
       THEN `packages/pipeline/src/processing/batch-embedding.ts` に変更される（バッチ処理）
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/tagging/extract.ts` への参照がある場合
       THEN `packages/shared/src/tagging/extract.ts` に変更される（純粋ロジック）
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/tagging/tag-dictionary-manager.ts` への参照がある場合
       THEN `packages/shared/src/tagging/tag-dictionary-manager.ts` に変更される（共通処理）
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/tagging/batch-processor.ts` への参照がある場合
       THEN `packages/pipeline/src/processing/batch-tagging.ts` に変更される（バッチ処理）
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/search/` への参照がある場合
       THEN `packages/shared/src/search/` に変更される
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/lib/` への参照がある場合
       THEN `packages/shared/src/lib/` に変更される
 
-- [ ] WHEN 003系specファイルを更新する際
+- [x] WHEN 003系specファイルを更新する際
       GIVEN `packages/poc/src/migrations/` への参照がある場合
       THEN `packages/pipeline/src/migrations/` に変更される
 
 ### EPIC成果物更新
 
-- [ ] WHEN 003-data-pipeline.md を更新する際
+- [x] WHEN 003-data-pipeline.md を更新する際
       GIVEN 成果物セクションに `packages/poc` への参照がある場合
       THEN 以下のように更新される: - `packages/poc/src/crawler/` → `packages/pipeline/src/crawler/` - `packages/poc/src/pipeline/` → `packages/pipeline/src/orchestrator/`
 
 ### 検証
 
-- [ ] WHEN grep で確認する際
+- [x] WHEN grep で確認する際
       GIVEN 003系specディレクトリを検索した場合
       THEN `packages/poc` への参照が0件である
 
@@ -148,6 +148,20 @@ grep -r "packages/poc" specs/003-data-pipeline/ | wc -l
 
 ## テストケース
 
-- [ ] 003系specディレクトリに `packages/poc` への参照が0件である
-- [ ] 各specファイルのパスが実際のファイル配置と一致する
-- [ ] markdownのリンクが壊れていない
+- [x] 003系specディレクトリに `packages/poc` への参照が0件である
+- [x] 各specファイルのパスが実際のファイル配置と一致する
+- [x] markdownのリンクが壊れていない
+
+## 実装状況
+
+- **status**: completed
+- **実装日**: 2026-01-14
+- **更新ファイル**:
+  - `003-data-pipeline.md` - 成果物セクション
+  - `003-01-db-foundation/003-01-01-language-schema.md` - テストファイルパス
+  - `003-01-db-foundation/003-01-02-tag-dictionary.md` - テストファイルパス
+  - `003-01-db-foundation/003-01-03-pipeline-tables.md` - テストファイルパス
+  - `003-02-crawler/003-02-01-crawler-abstraction.md` - 実装ファイルパス
+  - `003-02-crawler/003-02-02-en-full-crawler.md` - 実装ファイルパス
+  - `003-02-crawler/003-02-03-diff-update.md` - 実装ファイルパス
+- **備考**: 003-03系、003-04系は既に正しいパスに更新されていたため変更不要

--- a/specs/003-data-pipeline/003-00-package-structure/subtask-list.md
+++ b/specs/003-data-pipeline/003-00-package-structure/subtask-list.md
@@ -5,4 +5,4 @@
 | [003-00-01](./003-00-01-create-shared.md)   | sharedパッケージ作成   | completed  | -         |
 | [003-00-02](./003-00-02-create-pipeline.md) | pipelineパッケージ作成 | completed  | 003-00-01 |
 | [003-00-03](./003-00-03-update-poc-refs.md) | PoC参照更新            | completed  | 003-00-02 |
-| [003-00-04](./003-00-04-update-specs.md)    | Spec修正               | pending    | 003-00-03 |
+| [003-00-04](./003-00-04-update-specs.md)    | Spec修正               | completed  | 003-00-03 |

--- a/specs/003-data-pipeline/003-01-db-foundation/003-01-01-language-schema.md
+++ b/specs/003-data-pipeline/003-01-db-foundation/003-01-01-language-schema.md
@@ -99,4 +99,4 @@ CREATE INDEX idx_scp_articles_is_deleted ON scp_articles(is_deleted) WHERE is_de
 
 - **status**: completed
 - **マイグレーションファイル**: `supabase/migrations/20250112000001_language_schema.sql`
-- **テストファイル**: `packages/poc/src/migrations/__dev__/003-01-01-language-schema.test.ts`
+- **テストファイル**: `packages/pipeline/src/migrations/__dev__/003-01-01-language-schema.test.ts`

--- a/specs/003-data-pipeline/003-01-db-foundation/003-01-02-tag-dictionary.md
+++ b/specs/003-data-pipeline/003-01-db-foundation/003-01-02-tag-dictionary.md
@@ -120,5 +120,5 @@ WHERE tl.lang = 'en'
 - **status**: completed
 - **実装ファイル**:
   - マイグレーション: `supabase/migrations/20250112000002_tag_dictionary.sql`
-  - テスト: `packages/poc/src/migrations/__dev__/003-01-02-tag-dictionary.test.ts`
+  - テスト: `packages/pipeline/src/migrations/__dev__/003-01-02-tag-dictionary.test.ts`
 - **実装日**: 2026-01-12

--- a/specs/003-data-pipeline/003-01-db-foundation/003-01-03-pipeline-tables.md
+++ b/specs/003-data-pipeline/003-01-db-foundation/003-01-03-pipeline-tables.md
@@ -147,4 +147,4 @@ CREATE INDEX idx_retry_queue_task_type ON retry_queue(task_type);
 
 - **status**: completed
 - **マイグレーションファイル**: `supabase/migrations/20250112000003_pipeline_tables.sql`
-- **テストファイル**: `packages/poc/src/migrations/__dev__/003-01-03-pipeline-tables.test.ts`
+- **テストファイル**: `packages/pipeline/src/migrations/__dev__/003-01-03-pipeline-tables.test.ts`

--- a/specs/003-data-pipeline/003-02-crawler/003-02-01-crawler-abstraction.md
+++ b/specs/003-data-pipeline/003-02-crawler/003-02-01-crawler-abstraction.md
@@ -50,7 +50,7 @@
 ### インターフェース定義
 
 ```typescript
-// packages/poc/src/crawler/types.ts
+// packages/pipeline/src/crawler/types.ts
 
 export interface ArticleIndex {
   id: string; // 'SCP-173'
@@ -89,7 +89,7 @@ export interface BranchCrawler {
 ### Factory 実装
 
 ```typescript
-// packages/poc/src/crawler/factory.ts
+// packages/pipeline/src/crawler/factory.ts
 
 import { BranchCrawler } from "./types";
 import { EnglishCrawler } from "./english-crawler";

--- a/specs/003-data-pipeline/003-02-crawler/003-02-02-en-full-crawler.md
+++ b/specs/003-data-pipeline/003-02-crawler/003-02-02-en-full-crawler.md
@@ -71,7 +71,7 @@ SCP Data APIを使用してEN全記事（series-1〜8+）を取得するクロ�
 ### EnglishCrawler 実装
 
 ```typescript
-// packages/poc/src/crawler/english-crawler.ts
+// packages/pipeline/src/crawler/english-crawler.ts
 
 import { BranchCrawler, ArticleIndex, ArticleContent } from "./types";
 

--- a/specs/003-data-pipeline/003-02-crawler/003-02-03-diff-update.md
+++ b/specs/003-data-pipeline/003-02-crawler/003-02-03-diff-update.md
@@ -86,7 +86,7 @@ flowchart TD
 ### インターフェース
 
 ```typescript
-// packages/poc/src/crawler/diff-crawler.ts
+// packages/pipeline/src/crawler/diff-crawler.ts
 
 export interface DiffCrawlOptions {
   lang: string;

--- a/specs/003-data-pipeline/003-data-pipeline.md
+++ b/specs/003-data-pipeline/003-data-pipeline.md
@@ -87,6 +87,6 @@ flowchart TB
 ## 成果物
 
 - DBマイグレーションスクリプト
-- 本番用クローラー（`packages/poc/src/crawler/`）
-- パイプラインオーケストレーター（`packages/poc/src/pipeline/`）
+- 本番用クローラー（`packages/pipeline/src/crawler/`）
+- パイプラインオーケストレーター（`packages/pipeline/src/orchestrator/`）
 - GitHub Actions ワークフロー（`.github/workflows/data-pipeline.yml`）

--- a/specs/003-data-pipeline/story-list.md
+++ b/specs/003-data-pipeline/story-list.md
@@ -2,7 +2,7 @@
 
 | ID                                                               | 名前                             | ステータス | 概要                                                 |
 | ---------------------------------------------------------------- | -------------------------------- | ---------- | ---------------------------------------------------- |
-| [003-00](./003-00-package-structure/003-00-package-structure.md) | パッケージ構造整備               | pending    | shared/pipelineパッケージ作成、PoCからの分離         |
+| [003-00](./003-00-package-structure/003-00-package-structure.md) | パッケージ構造整備               | completed  | shared/pipelineパッケージ作成、PoCからの分離         |
 | [003-01](./003-01-db-foundation/003-01-db-foundation.md)         | DB基盤拡張                       | completed  | 言語マスタ、タグ辞書、パイプライン管理テーブルの追加 |
 | [003-02](./003-02-crawler/003-02-crawler.md)                     | クローラー本番化                 | pending    | 抽象化レイヤー、EN全記事クロール、差分更新           |
 | [003-03](./003-03-processing/003-03-processing.md)               | Embedding/タグ処理本番化         | pending    | バッチ処理、タグ辞書マネージャー、ステータス管理     |


### PR DESCRIPTION
003系specファイル内のpackages/poc参照を適切なパッケージに更新:
- packages/poc/src/crawler/ → packages/pipeline/src/crawler/
- packages/poc/src/migrations/ → packages/pipeline/src/migrations/
- packages/poc/src/pipeline/ → packages/pipeline/src/orchestrator/

更新対象ファイル:
- 003-data-pipeline.md (成果物セクション)
- 003-01系 (テストファイルパス)
- 003-02系 (実装ファイルパス)

Story-003-00完了: 全Subtask (003-00-01〜04) が完了