### PR TITLE
feat(pipeline): 003-02-04 pinoロギング導入

### DIFF
--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -15,10 +15,12 @@
   },
   "dependencies": {
     "@recommend-scp/shared": "workspace:*",
-    "@supabase/supabase-js": "^2.49.1"
+    "@supabase/supabase-js": "^2.49.1",
+    "pino": "^10.2.0"
   },
   "devDependencies": {
-    "@types/node": "^22.10.2",
+    "@types/node": "^22.19.3",
+    "pino-pretty": "^13.1.3",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^4.0.16"

--- a/packages/pipeline/src/crawler/utils/__dev__/logger.test.ts
+++ b/packages/pipeline/src/crawler/utils/__dev__/logger.test.ts
@@ -1,0 +1,420 @@
+/**
+ * pinoロギングのテスト
+ * Subtask: 003-02-04
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLogger } from "../logger";
+
+/** pinoログ出力の型定義 */
+interface PinoLogOutput {
+  time: number;
+  level: number;
+  msg: string;
+  pid: number;
+  hostname: string;
+  prefix?: string;
+  articleId?: string;
+  lang?: string;
+  err?: {
+    message: string;
+    stack?: string;
+    name: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+// pinoモジュールを初期化（stdoutキャッシュを確立）
+beforeAll(() => {
+  const initLogger = createLogger({ silent: true });
+  initLogger.info("init");
+});
+
+/**
+ * 非同期ログ出力をキャプチャするヘルパー
+ */
+async function captureOutputAsync(fn: () => void): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encoding?: BufferEncoding | ((err?: Error) => void),
+    callback?: (err?: Error) => void
+  ): boolean => {
+    if (typeof chunk === "string") {
+      chunks.push(chunk);
+    } else {
+      chunks.push(chunk.toString());
+    }
+    if (typeof encoding === "function") {
+      encoding();
+    } else if (callback) {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    fn();
+    // pinoは非同期で出力するため、少し待つ
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return chunks.join("");
+}
+
+/**
+ * JSON出力をパースするヘルパー
+ */
+function parseLogOutput(output: string): PinoLogOutput {
+  return JSON.parse(output.trim().split("\n")[0]) as PinoLogOutput;
+}
+
+describe("logger", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // 環境変数のクリーンアップ
+    delete process.env.LOG_LEVEL;
+    delete process.env.GITHUB_ACTIONS;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("pino導入", () => {
+    it("pinoが依存関係に含まれる", async () => {
+      const pkg = await import("../../../../package.json");
+      expect(pkg.dependencies).toHaveProperty("pino");
+    });
+
+    // Note: debugレベルの動作は「levelが正しく出力される」テストでカバー
+
+    it("環境変数LOG_LEVELがinfoの場合、debugは出力されない", async () => {
+      process.env.LOG_LEVEL = "info";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debugメッセージ");
+      });
+
+      expect(output).not.toContain("debugメッセージ");
+    });
+
+    it("環境変数LOG_LEVELがwarnの場合、infoは出力されない", async () => {
+      process.env.LOG_LEVEL = "warn";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("infoメッセージ");
+      });
+
+      expect(output).not.toContain("infoメッセージ");
+    });
+
+    it("環境変数LOG_LEVELがerrorの場合、warnは出力されない", async () => {
+      process.env.LOG_LEVEL = "error";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.warn("warnメッセージ");
+      });
+
+      expect(output).not.toContain("warnメッセージ");
+    });
+
+    it("LOG_LEVELが未設定の場合、デフォルト（info）で動作する", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debugメッセージ");
+        logger.info("infoメッセージ");
+      });
+
+      expect(output).not.toContain("debugメッセージ");
+      expect(output).toContain("infoメッセージ");
+    });
+
+    it("LOG_LEVELが大文字の場合、正規化されて動作する", async () => {
+      process.env.LOG_LEVEL = "DEBUG";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debugテストメッセージ");
+      });
+
+      expect(output).toContain("debugテストメッセージ");
+    });
+
+    it("LOG_LEVELが不正な値の場合、デフォルトレベルで動作する", async () => {
+      process.env.LOG_LEVEL = "invalid";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debugメッセージ");
+        logger.info("infoメッセージ");
+      });
+
+      expect(output).not.toContain("debugメッセージ");
+      expect(output).toContain("infoメッセージ");
+    });
+  });
+
+  describe("構造化ログ", () => {
+    it("ログがJSON形式で出力される", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      // JSON形式かどうかをパースで確認
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThan(0);
+      expect(() => JSON.parse(lines[0]) as PinoLogOutput).not.toThrow();
+    });
+
+    it("timestampが含まれる", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      const parsed = parseLogOutput(output);
+      // pinoはtimeプロパティにUnixタイムスタンプを出力
+      expect(parsed).toHaveProperty("time");
+    });
+
+    it("levelが正しく出力される", async () => {
+      const logger = createLogger({ level: "debug" });
+
+      const debugOutput = await captureOutputAsync(() => {
+        logger.debug("debug");
+      });
+      const infoOutput = await captureOutputAsync(() => {
+        logger.info("info");
+      });
+      const warnOutput = await captureOutputAsync(() => {
+        logger.warn("warn");
+      });
+      const errorOutput = await captureOutputAsync(() => {
+        logger.error("error");
+      });
+
+      expect(parseLogOutput(debugOutput)).toHaveProperty("level", 20); // pino debug level
+      expect(parseLogOutput(infoOutput)).toHaveProperty("level", 30); // pino info level
+      expect(parseLogOutput(warnOutput)).toHaveProperty("level", 40); // pino warn level
+      expect(parseLogOutput(errorOutput)).toHaveProperty("level", 50); // pino error level
+    });
+
+    it("messageが正しく出力される", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージです");
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed).toHaveProperty("msg", "テストメッセージです");
+    });
+
+    it("contextが追加情報として含まれる", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("記事取得", { articleId: "scp-173", lang: "en" });
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed).toHaveProperty("articleId", "scp-173");
+      expect(parsed).toHaveProperty("lang", "en");
+    });
+
+    it("Errorオブジェクトが渡された場合、スタックトレースも含まれる", async () => {
+      const logger = createLogger();
+      const error = new Error("テストエラー");
+
+      const output = await captureOutputAsync(() => {
+        logger.error("エラーが発生", error);
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed).toHaveProperty("err");
+      expect(parsed.err).toHaveProperty("message", "テストエラー");
+      expect(parsed.err).toHaveProperty("stack");
+      expect(parsed.err?.stack).toContain("Error: テストエラー");
+    });
+
+    it("messageが空文字の場合でもエラーにならない", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("");
+      });
+
+      expect(() => JSON.parse(output.trim().split("\n")[0]) as PinoLogOutput).not.toThrow();
+    });
+
+    it("messageに特殊文字が含まれる場合、エスケープされる", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info('特殊文字: "引用符", \\バックスラッシュ, \n改行');
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed.msg).toContain("特殊文字");
+    });
+  });
+
+  describe("ラッパー移行", () => {
+    it("既存インターフェースが維持される", () => {
+      const logger = createLogger({ prefix: "[Test]" });
+
+      expect(logger).toHaveProperty("debug");
+      expect(logger).toHaveProperty("info");
+      expect(logger).toHaveProperty("warn");
+      expect(logger).toHaveProperty("error");
+      expect(typeof logger.debug).toBe("function");
+      expect(typeof logger.info).toBe("function");
+      expect(typeof logger.warn).toBe("function");
+      expect(typeof logger.error).toBe("function");
+    });
+
+    it("呼び出し側のコードは変更不要（エラーにならない）", () => {
+      const logger = createLogger({ prefix: "[Test]" });
+
+      expect(() => {
+        logger.debug("debug");
+        logger.info("info");
+        logger.warn("warn");
+        logger.error("error");
+      }).not.toThrow();
+    });
+
+    it("silentオプションを指定した際、ログ出力が無効化される", async () => {
+      const logger = createLogger({ silent: true });
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debug");
+        logger.info("info");
+        logger.warn("warn");
+        logger.error("error");
+      });
+
+      expect(output).toBe("");
+    });
+
+    it("prefixが正しく適用される", async () => {
+      const logger = createLogger({ prefix: "[Crawler]" });
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed).toHaveProperty("prefix", "[Crawler]");
+    });
+
+    it("prefixが空文字の場合、prefixプロパティが含まれない", async () => {
+      const logger = createLogger({ prefix: "" });
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      const parsed = parseLogOutput(output);
+      expect(parsed.prefix).toBeUndefined();
+    });
+
+    it("オプションオブジェクトが空の場合、デフォルト設定で動作する", async () => {
+      const logger = createLogger({});
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      expect(output).toContain("テストメッセージ");
+    });
+
+    it("levelオプションが指定された場合、環境変数より優先される", async () => {
+      process.env.LOG_LEVEL = "error";
+      const logger = createLogger({ level: "debug" });
+
+      const output = await captureOutputAsync(() => {
+        logger.debug("debugメッセージ");
+      });
+
+      expect(output).toContain("debugメッセージ");
+    });
+  });
+
+  describe("GitHub Actions対応", () => {
+    it("GitHub Actions環境で実行された際、ログがworkflowログに出力される", async () => {
+      process.env.GITHUB_ACTIONS = "true";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.info("テストメッセージ");
+      });
+
+      expect(output).toContain("テストメッセージ");
+    });
+
+    it("warnログがGitHub Actionsの警告形式で出力される", async () => {
+      process.env.GITHUB_ACTIONS = "true";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.warn("警告メッセージ");
+      });
+
+      expect(output).toContain("::warning::");
+    });
+
+    it("errorログがGitHub Actionsのエラー形式で出力される", async () => {
+      process.env.GITHUB_ACTIONS = "true";
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.error("エラーメッセージ");
+      });
+
+      expect(output).toContain("::error::");
+    });
+
+    it("GITHUB_ACTIONSが未設定の場合、通常のJSON形式で出力される", async () => {
+      const logger = createLogger();
+
+      const output = await captureOutputAsync(() => {
+        logger.warn("警告メッセージ");
+      });
+
+      expect(output).not.toContain("::warning::");
+      expect(() => JSON.parse(output.trim().split("\n")[0]) as PinoLogOutput).not.toThrow();
+    });
+  });
+
+  describe("crawlerLogger（デフォルトインスタンス）", () => {
+    it("prefixが[Crawler]でエクスポートされる", async () => {
+      // モジュールキャッシュをクリアして再インポート
+      vi.resetModules();
+      const { crawlerLogger } = await import("../logger");
+
+      const output = await captureOutputAsync(() => {
+        crawlerLogger.info("テストメッセージ");
+      });
+
+      const lines = output.trim().split("\n").filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      const parsed = JSON.parse(lines[0]) as PinoLogOutput;
+      expect(parsed).toHaveProperty("prefix", "[Crawler]");
+    });
+  });
+});

--- a/packages/pipeline/src/crawler/utils/logger.ts
+++ b/packages/pipeline/src/crawler/utils/logger.ts
@@ -1,10 +1,11 @@
 /**
  * ロガーユーティリティ
- * Subtask: 003-02-02
+ * Subtask: 003-02-04
  *
- * 現在はconsole.logのラッパーとして実装。
- * 将来的にpinoに置き換え予定（003-02-04で対応予定）。
+ * pinoベースの構造化ロギング。
+ * GitHub Actions対応（warn/errorは ::warning::/::error:: 形式で出力）。
  */
+import pino from "pino";
 
 /** ログレベル */
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -27,11 +28,51 @@ export interface LoggerOptions {
   silent?: boolean;
 }
 
-const LOG_LEVELS: Record<LogLevel, number> = {
-  debug: 0,
-  info: 1,
-  warn: 2,
-  error: 3,
+const VALID_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+
+/**
+ * 環境変数からログレベルを取得
+ */
+const getLogLevelFromEnv = (): LogLevel | undefined => {
+  const envLevel = process.env.LOG_LEVEL?.toLowerCase().trim();
+  if (envLevel && VALID_LEVELS.includes(envLevel as LogLevel)) {
+    return envLevel as LogLevel;
+  }
+  return undefined;
+};
+
+/**
+ * GitHub Actions環境かどうかを判定
+ */
+const isGitHubActions = (): boolean => {
+  return process.env.GITHUB_ACTIONS === "true" || process.env.GITHUB_ACTIONS === "1";
+};
+
+/**
+ * GitHub Actions用のログフォーマッタを作成
+ */
+const createGitHubActionsHook = () => {
+  return {
+    logMethod(inputArgs: Parameters<pino.LogFn>, method: pino.LogFn, level: number) {
+      // 通常のログ出力
+      method.apply(this, inputArgs);
+
+      // warn/errorの場合はGitHub Actions形式でも出力
+      if (level >= 40) {
+        const message =
+          typeof inputArgs[0] === "string"
+            ? inputArgs[0]
+            : typeof inputArgs[1] === "string"
+              ? inputArgs[1]
+              : "";
+
+        if (message) {
+          const prefix = level >= 50 ? "::error::" : "::warning::";
+          process.stdout.write(`${prefix}${message}\n`);
+        }
+      }
+    },
+  };
 };
 
 /**
@@ -39,41 +80,73 @@ const LOG_LEVELS: Record<LogLevel, number> = {
  * @param options ロガーオプション
  */
 export const createLogger = (options: LoggerOptions = {}): Logger => {
-  const { prefix = "", level = "info", silent = false } = options;
+  const { prefix = "", level, silent = false } = options;
 
-  const shouldLog = (targetLevel: LogLevel): boolean => {
-    if (silent) return false;
-    return LOG_LEVELS[targetLevel] >= LOG_LEVELS[level];
+  // レベルの優先順位: オプション > 環境変数 > デフォルト（info）
+  const effectiveLevel = silent ? "silent" : (level ?? getLogLevelFromEnv() ?? "info");
+
+  const pinoOptions: pino.LoggerOptions = {
+    level: effectiveLevel,
   };
 
-  const formatMessage = (message: string): string => {
-    return prefix ? `${prefix} ${message}` : message;
+  // GitHub Actions環境ではhookを追加
+  if (isGitHubActions()) {
+    pinoOptions.hooks = createGitHubActionsHook();
+  }
+
+  const pinoInstance = pino(pinoOptions);
+
+  /**
+   * ログ出力のラッパー
+   * contextオブジェクトとErrorオブジェクトを適切に処理
+   */
+  const log = (pinoMethod: pino.LogFn, message: string, args: unknown[]): void => {
+    // contextオブジェクトを構築
+    const context: Record<string, unknown> = {};
+
+    // prefixがあれば追加
+    if (prefix) {
+      context.prefix = prefix;
+    }
+
+    // 引数を処理
+    for (const arg of args) {
+      if (arg instanceof Error) {
+        // Errorオブジェクトはerrプロパティとして追加
+        context.err = {
+          message: arg.message,
+          stack: arg.stack,
+          name: arg.name,
+          ...Object.fromEntries(
+            Object.entries(arg).filter(([key]) => !["message", "stack", "name"].includes(key))
+          ),
+        };
+      } else if (typeof arg === "object" && arg !== null) {
+        // オブジェクトはcontextにマージ
+        Object.assign(context, arg);
+      }
+    }
+
+    // ログ出力
+    if (Object.keys(context).length > 0) {
+      pinoMethod.call(pinoInstance, context, message);
+    } else {
+      pinoMethod.call(pinoInstance, message);
+    }
   };
 
   return {
     debug: (message: string, ...args: unknown[]) => {
-      if (shouldLog("debug")) {
-        // eslint-disable-next-line no-console
-        console.debug(formatMessage(message), ...args);
-      }
+      log(pinoInstance.debug, message, args);
     },
     info: (message: string, ...args: unknown[]) => {
-      if (shouldLog("info")) {
-        // eslint-disable-next-line no-console
-        console.log(formatMessage(message), ...args);
-      }
+      log(pinoInstance.info, message, args);
     },
     warn: (message: string, ...args: unknown[]) => {
-      if (shouldLog("warn")) {
-        // eslint-disable-next-line no-console
-        console.warn(formatMessage(message), ...args);
-      }
+      log(pinoInstance.warn, message, args);
     },
     error: (message: string, ...args: unknown[]) => {
-      if (shouldLog("error")) {
-        // eslint-disable-next-line no-console
-        console.error(formatMessage(message), ...args);
-      }
+      log(pinoInstance.error, message, args);
     },
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,10 +47,16 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.89.0
+      pino:
+        specifier: ^10.2.0
+        version: 10.2.0
     devDependencies:
       '@types/node':
-        specifier: ^22.10.2
+        specifier: ^22.19.3
         version: 22.19.3
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -424,6 +430,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@rollup/rollup-android-arm-eabi@4.54.0':
     resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
     cpu: [arm]
@@ -740,6 +749,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -779,6 +792,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -828,6 +844,9 @@ packages:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
 
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -858,6 +877,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -957,6 +979,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-copy@4.0.2:
+    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -965,6 +990,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1068,6 +1096,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1146,6 +1177,10 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1339,6 +1374,13 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
     hasBin: true
@@ -1401,6 +1443,20 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.2.0:
+    resolution: {integrity: sha512-NFnZqUliT+OHkRXVSf8vdOr13N1wv31hRryVjqbreVh/SDCNaI6mnRDDq89HVRCbem1SAl7yj04OANeqP0nT6A==}
+    hasBin: true
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1414,9 +1470,22 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1442,6 +1511,13 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -1457,6 +1533,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1484,6 +1563,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1491,6 +1574,10 @@ packages:
   text-extensions@2.4.0:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
     engines: {node: '>=8'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -1691,6 +1778,9 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -2003,6 +2093,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
@@ -2344,6 +2436,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   balanced-match@1.0.2: {}
 
   brace-expansion@1.1.12:
@@ -2382,6 +2476,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -2433,6 +2529,8 @@ snapshots:
 
   dargs@8.1.0: {}
 
+  dateformat@4.6.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2454,6 +2552,10 @@ snapshots:
       gopd: 1.2.0
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   env-paths@2.2.1: {}
 
@@ -2591,11 +2693,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-copy@4.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
 
@@ -2699,6 +2805,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   html-escaper@2.0.2: {}
 
   humanize-ms@1.2.1:
@@ -2762,6 +2870,8 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   jiti@2.6.1: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -2911,6 +3021,12 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   openai@4.104.0(ws@8.18.3)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -2974,6 +3090,42 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.2.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 4.0.0
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -2984,7 +3136,18 @@ snapshots:
 
   prettier@3.7.4: {}
 
+  process-warning@5.0.0: {}
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  real-require@0.2.0: {}
 
   require-directory@2.1.1: {}
 
@@ -3024,6 +3187,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
+  safe-stable-stringify@2.5.0: {}
+
+  secure-json-parse@4.1.0: {}
+
   semver@7.7.3: {}
 
   shebang-command@2.0.0:
@@ -3033,6 +3200,10 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -3054,11 +3225,17 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   text-extensions@2.4.0: {}
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   through@2.3.8: {}
 
@@ -3218,6 +3395,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   ws@8.18.3: {}
 

--- a/specs/003-data-pipeline/003-02-crawler/003-02-04-pino-logging.md
+++ b/specs/003-data-pipeline/003-02-crawler/003-02-04-pino-logging.md
@@ -4,7 +4,7 @@
 
 - **ID**: 003-02-04
 - **名前**: pinoロギング導入
-- **ステータス**: pending
+- **ステータス**: completed
 - **依存**: 003-02-02
 
 ## ユーザーストーリー
@@ -17,36 +17,36 @@
 
 ### pino導入
 
-- [ ] WHEN pipelineパッケージをビルドした際
+- [x] WHEN pipelineパッケージをビルドした際
       THEN pinoがサーバーサイド用ライブラリとして含まれる
       AND クライアントサイド（ブラウザ）では使用されない
 
-- [ ] WHEN ロガーを初期化した際
+- [x] WHEN ロガーを初期化した際
       GIVEN 環境変数 LOG_LEVEL が設定されている場合
       THEN 指定されたレベル（debug/info/warn/error）で動作する
 
 ### 構造化ログ
 
-- [ ] WHEN クロール処理のログを出力した際
+- [x] WHEN クロール処理のログを出力した際
       THEN JSON形式で出力される
       AND timestamp, level, message, context を含む
 
-- [ ] WHEN エラーログを出力した際
+- [x] WHEN エラーログを出力した際
       GIVEN Errorオブジェクトが渡された場合
       THEN スタックトレースも含まれる
 
 ### ラッパー移行
 
-- [ ] WHEN 既存の logger ラッパーを更新した際
+- [x] WHEN 既存の logger ラッパーを更新した際
       THEN createLogger の内部実装がpinoに変更される
       AND 呼び出し側のコードは変更不要
 
-- [ ] WHEN silent オプションを指定した際
+- [x] WHEN silent オプションを指定した際
       THEN ログ出力が無効化される（テスト用）
 
 ### GitHub Actions対応
 
-- [ ] WHEN GitHub Actionsで実行された際
+- [x] WHEN GitHub Actionsで実行された際
       THEN ログがworkflowログに出力される
       AND 重要なログはサマリーにも表示される
 
@@ -66,10 +66,10 @@ packages/pipeline/src/
 ```json
 {
   "dependencies": {
-    "pino": "^9.x"
+    "pino": "^10.x"
   },
   "devDependencies": {
-    "pino-pretty": "^11.x"
+    "pino-pretty": "^13.x"
   }
 }
 ```
@@ -101,11 +101,19 @@ export const createLogger = (options: LoggerOptions = {}): Logger => {
 
 ## テストケース
 
-- [ ] pino経由でログが出力される
-- [ ] ログレベルの設定が機能する
-- [ ] silentモードでログが抑制される
-- [ ] JSON形式で出力される（pino-prettyなし時）
-- [ ] 既存のテストが引き続き通る
+- [x] pino経由でログが出力される
+- [x] ログレベルの設定が機能する
+- [x] silentモードでログが抑制される
+- [x] JSON形式で出力される（pino-prettyなし時）
+- [x] 既存のテストが引き続き通る
+
+## 実装状況
+
+- **status**: completed
+- **完了日**: 2026-01-16
+- **実装ファイル**:
+  - `packages/pipeline/src/crawler/utils/logger.ts` - pinoベースに移行
+  - `packages/pipeline/src/crawler/utils/__dev__/logger.test.ts` - テスト追加
 
 ## 備考
 

--- a/specs/003-data-pipeline/003-02-crawler/subtask-list.md
+++ b/specs/003-data-pipeline/003-02-crawler/subtask-list.md
@@ -5,4 +5,4 @@
 | [003-02-01](./003-02-01-crawler-abstraction.md) | クローラー抽象化レイヤー | completed  | 003-01-01 |
 | [003-02-02](./003-02-02-en-full-crawler.md)     | EN全記事クローラー       | completed  | 003-02-01 |
 | [003-02-03](./003-02-03-diff-update.md)         | 差分更新機能             | completed  | 003-02-02 |
-| [003-02-04](./003-02-04-pino-logging.md)        | pinoロギング導入         | pending    | 003-02-02 |
+| [003-02-04](./003-02-04-pino-logging.md)        | pinoロギング導入         | completed  | 003-02-02 |


### PR DESCRIPTION
- logger.tsをconsole.logベースからpinoベースに移行
- 構造化ログ出力（JSON形式、timestamp、level、context対応）
- 環境変数LOG_LEVELでのログレベル制御
- Errorオブジェクトのスタックトレース出力
- silentオプションでテスト時のログ抑制
- GitHub Actions対応（::warning::/::error:: 形式）
- 既存インターフェース維持（呼び出し側変更不要）