### PR TITLE
feat(shared): 004-01-06 お気に入り機能を実装

### DIFF
--- a/packages/shared/src/onboarding/onboarding-service.test.ts
+++ b/packages/shared/src/onboarding/onboarding-service.test.ts
@@ -31,6 +31,9 @@ function createMockStorage(): PreferenceStorage {
     addRecommendationLog: vi.fn().mockResolvedValue(undefined),
     getDislikedArticleIds: vi.fn().mockResolvedValue([]),
     getArticleTags: vi.fn().mockResolvedValue(null),
+    getFavorites: vi.fn().mockResolvedValue([]),
+    addFavorite: vi.fn().mockResolvedValue(undefined),
+    removeFavorite: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/packages/shared/src/recommendation/__tests__/profiler.test.ts
+++ b/packages/shared/src/recommendation/__tests__/profiler.test.ts
@@ -83,6 +83,18 @@ class MockPreferenceStorage implements PreferenceStorage {
     return this.articleTags.get(articleId) ?? null;
   }
 
+  async getFavorites(_visitorId: string): Promise<import("../../storage/types").Favorite[]> {
+    return [];
+  }
+
+  async addFavorite(_favorite: import("../../storage/types").Favorite): Promise<void> {
+    // no-op for this mock
+  }
+
+  async removeFavorite(_visitorId: string, _articleId: string): Promise<void> {
+    // no-op for this mock
+  }
+
   // テスト用ヘルパーメソッド
   setArticleTags(articleId: string, tags: string[]): void {
     this.articleTags.set(articleId, tags);

--- a/packages/shared/src/recommendation/__tests__/signal-processor.test.ts
+++ b/packages/shared/src/recommendation/__tests__/signal-processor.test.ts
@@ -89,6 +89,18 @@ class MockPreferenceStorage implements PreferenceStorage {
     return this.articleTags.get(articleId) ?? null;
   }
 
+  async getFavorites(_visitorId: string): Promise<import("../../storage/types").Favorite[]> {
+    return [];
+  }
+
+  async addFavorite(_favorite: import("../../storage/types").Favorite): Promise<void> {
+    // no-op for this mock
+  }
+
+  async removeFavorite(_visitorId: string, _articleId: string): Promise<void> {
+    // no-op for this mock
+  }
+
   // テスト用ヘルパーメソッド
   setArticleTags(articleId: string, tags: string[]): void {
     this.articleTags.set(articleId, tags);

--- a/packages/shared/src/storage/composite-storage.test.ts
+++ b/packages/shared/src/storage/composite-storage.test.ts
@@ -31,6 +31,9 @@ function createMockLocalStorage(): PreferenceStorage {
     addRecommendationLog: vi.fn(),
     getDislikedArticleIds: vi.fn(),
     getArticleTags: vi.fn(),
+    getFavorites: vi.fn(),
+    addFavorite: vi.fn(),
+    removeFavorite: vi.fn(),
   };
 }
 

--- a/packages/shared/src/storage/composite-storage.ts
+++ b/packages/shared/src/storage/composite-storage.ts
@@ -10,6 +10,7 @@ import type {
   ViewHistory,
   Feedback,
   RecommendationLog,
+  Favorite,
 } from "./types";
 import type { SupabaseTagStorage } from "./supabase-tag-storage";
 
@@ -125,5 +126,31 @@ export class CompositeStorage implements PreferenceStorage {
    */
   getArticleTags(articleId: string): Promise<string[] | null> {
     return this.tagStorage.getArticleTags(articleId);
+  }
+
+  /**
+   * お気に入り一覧を取得
+   * @param visitorId 訪問者ID
+   * @returns お気に入りの配列（追加日時降順）
+   */
+  getFavorites(visitorId: string): Promise<Favorite[]> {
+    return this.localStorage.getFavorites(visitorId);
+  }
+
+  /**
+   * お気に入りを追加
+   * @param favorite 追加するお気に入り
+   */
+  addFavorite(favorite: Favorite): Promise<void> {
+    return this.localStorage.addFavorite(favorite);
+  }
+
+  /**
+   * お気に入りを解除
+   * @param visitorId 訪問者ID
+   * @param articleId 記事ID
+   */
+  removeFavorite(visitorId: string, articleId: string): Promise<void> {
+    return this.localStorage.removeFavorite(visitorId, articleId);
   }
 }

--- a/packages/shared/src/storage/indexed-db-favorite.test.ts
+++ b/packages/shared/src/storage/indexed-db-favorite.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @file IndexedDB お気に入り機能テスト
+ * @description Subtask 004-01-06 のACを検証するテスト
+ * @see specs/004-recommend/004-01-recommend-foundation/004-01-06.md
+ */
+
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { IndexedDBStorage } from "./indexed-db";
+import type { Favorite } from "./types";
+
+describe("004-01-06: お気に入り機能", () => {
+  let storage: IndexedDBStorage;
+
+  beforeEach(async () => {
+    // 各テスト前にDBをクリーンアップ
+    const dbs = await indexedDB.databases();
+    for (const db of dbs as { name?: string }[]) {
+      if (db.name) {
+        indexedDB.deleteDatabase(db.name);
+      }
+    }
+    storage = new IndexedDBStorage();
+  });
+
+  afterEach(async () => {
+    // テスト後のクリーンアップ
+    if (storage) {
+      storage.close();
+    }
+    indexedDB.deleteDatabase("scp-recommend");
+  });
+
+  describe("AC1: お気に入り追加", () => {
+    beforeEach(async () => {
+      await storage.initialize();
+    });
+
+    it("お気に入りを追加すると保存される", async () => {
+      // Arrange
+      const favorite: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+
+      // Act
+      await storage.addFavorite(favorite);
+
+      // Assert
+      const favorites = await storage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0]).toEqual(favorite);
+    });
+
+    it("複数のお気に入りを追加できる", async () => {
+      // Arrange
+      const favorite1: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+      const favorite2: Favorite = {
+        id: "visitor1_scp-682",
+        visitorId: "visitor1",
+        articleId: "scp-682",
+        addedAt: "2026-01-22T00:01:00Z",
+      };
+
+      // Act
+      await storage.addFavorite(favorite1);
+      await storage.addFavorite(favorite2);
+
+      // Assert
+      const favorites = await storage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(2);
+    });
+  });
+
+  describe("AC2: お気に入り一覧取得", () => {
+    beforeEach(async () => {
+      await storage.initialize();
+    });
+
+    it("お気に入り一覧が追加日時降順で返される", async () => {
+      // Arrange
+      const favorite1: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+      const favorite2: Favorite = {
+        id: "visitor1_scp-682",
+        visitorId: "visitor1",
+        articleId: "scp-682",
+        addedAt: "2026-01-22T00:02:00Z", // 後に追加
+      };
+      await storage.addFavorite(favorite1);
+      await storage.addFavorite(favorite2);
+
+      // Act
+      const favorites = await storage.getFavorites("visitor1");
+
+      // Assert
+      expect(favorites[0].articleId).toBe("scp-682"); // 新しい方が先
+      expect(favorites[1].articleId).toBe("scp-173");
+    });
+
+    it("お気に入りが0件の場合は空配列を返す", async () => {
+      // Act
+      const favorites = await storage.getFavorites("non-existent-visitor");
+
+      // Assert
+      expect(favorites).toEqual([]);
+    });
+
+    it("異なるvisitorIdのお気に入りは混在しない", async () => {
+      // Arrange
+      await storage.addFavorite({
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      });
+      await storage.addFavorite({
+        id: "visitor2_scp-682",
+        visitorId: "visitor2",
+        articleId: "scp-682",
+        addedAt: "2026-01-22T00:01:00Z",
+      });
+
+      // Act
+      const visitor1Favorites = await storage.getFavorites("visitor1");
+
+      // Assert
+      expect(visitor1Favorites).toHaveLength(1);
+      expect(visitor1Favorites[0].articleId).toBe("scp-173");
+    });
+  });
+
+  describe("AC3: お気に入り解除", () => {
+    beforeEach(async () => {
+      await storage.initialize();
+    });
+
+    it("お気に入りを解除すると削除される", async () => {
+      // Arrange
+      const favorite: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+      await storage.addFavorite(favorite);
+
+      // Act
+      await storage.removeFavorite("visitor1", "scp-173");
+
+      // Assert
+      const favorites = await storage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(0);
+    });
+
+    it("お気に入り解除後、他のお気に入りは残る", async () => {
+      // Arrange
+      await storage.addFavorite({
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      });
+      await storage.addFavorite({
+        id: "visitor1_scp-682",
+        visitorId: "visitor1",
+        articleId: "scp-682",
+        addedAt: "2026-01-22T00:01:00Z",
+      });
+
+      // Act
+      await storage.removeFavorite("visitor1", "scp-173");
+
+      // Assert
+      const favorites = await storage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0].articleId).toBe("scp-682");
+    });
+
+    it("存在しないお気に入りを解除してもエラーにならない", async () => {
+      // Act & Assert
+      await expect(
+        storage.removeFavorite("visitor1", "non-existent-article")
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("AC4: 重複追加時の動作", () => {
+    beforeEach(async () => {
+      await storage.initialize();
+    });
+
+    it("同じ記事を再度追加すると追加日時が更新される", async () => {
+      // Arrange
+      const favorite1: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+      const favorite2: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T01:00:00Z", // 1時間後
+      };
+
+      // Act
+      await storage.addFavorite(favorite1);
+      await storage.addFavorite(favorite2);
+
+      // Assert
+      const favorites = await storage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(1); // レコード数は1のまま
+      expect(favorites[0].addedAt).toBe("2026-01-22T01:00:00Z"); // 更新されている
+    });
+
+    it("重複エラーが発生しない", async () => {
+      // Arrange
+      const favorite: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+
+      // Act & Assert
+      await expect(storage.addFavorite(favorite)).resolves.not.toThrow();
+      await expect(storage.addFavorite(favorite)).resolves.not.toThrow(); // 2回目もエラーなし
+    });
+  });
+
+  describe("AC5: PreferenceStorageインターフェース拡張", () => {
+    beforeEach(async () => {
+      await storage.initialize();
+    });
+
+    it("getFavoritesメソッドが存在する", () => {
+      expect(typeof storage.getFavorites).toBe("function");
+    });
+
+    it("addFavoriteメソッドが存在する", () => {
+      expect(typeof storage.addFavorite).toBe("function");
+    });
+
+    it("removeFavoriteメソッドが存在する", () => {
+      expect(typeof storage.removeFavorite).toBe("function");
+    });
+  });
+
+  describe("データベース初期化", () => {
+    it("初期化時にfavoritesオブジェクトストアが作成される", async () => {
+      // Act
+      await storage.initialize();
+
+      // Assert
+      const storeNames = storage.getStoreNames();
+      expect(storeNames).toContain("favorites");
+    });
+
+    it("favoritesストアにbyVisitorインデックスが作成される", async () => {
+      // Act
+      await storage.initialize();
+
+      // Assert
+      const indexNames = storage.getIndexNames("favorites");
+      expect(indexNames).toContain("byVisitor");
+    });
+
+    it("既にDBが存在する状態で再初期化しても既存お気に入りは保持される", async () => {
+      // Arrange
+      await storage.initialize();
+      const favorite: Favorite = {
+        id: "visitor1_scp-173",
+        visitorId: "visitor1",
+        articleId: "scp-173",
+        addedAt: "2026-01-22T00:00:00Z",
+      };
+      await storage.addFavorite(favorite);
+      storage.close();
+
+      // Act
+      const newStorage = new IndexedDBStorage();
+      await newStorage.initialize();
+
+      // Assert
+      const favorites = await newStorage.getFavorites("visitor1");
+      expect(favorites).toHaveLength(1);
+      expect(favorites[0]).toEqual(favorite);
+
+      newStorage.close();
+    });
+  });
+});

--- a/packages/shared/src/storage/indexed-db.test.ts
+++ b/packages/shared/src/storage/indexed-db.test.ts
@@ -40,7 +40,7 @@ describe("004-01-02: IndexedDB実装", () => {
       const dbs = (await indexedDB.databases()) as { name?: string; version?: number }[];
       const targetDb = dbs.find((db) => db.name === "scp-recommend");
       expect(targetDb).toBeDefined();
-      expect(targetDb?.version).toBe(1);
+      expect(targetDb?.version).toBe(2);
     });
 
     it("初期化時に全てのオブジェクトストアが作成される", async () => {

--- a/packages/shared/src/storage/indexed-db.ts
+++ b/packages/shared/src/storage/indexed-db.ts
@@ -10,16 +10,18 @@ import type {
   ViewHistory,
   Feedback,
   RecommendationLog,
+  Favorite,
 } from "./types";
 
 const DB_NAME = "scp-recommend";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 const STORE_NAMES = {
   preferences: "preferences",
   viewHistory: "viewHistory",
   feedback: "feedback",
   recommendationLog: "recommendationLog",
+  favorites: "favorites",
 } as const;
 
 /**
@@ -86,6 +88,14 @@ export class IndexedDBStorage implements PreferenceStorage {
           });
           recLogStore.createIndex("byVisitor", "visitorId", { unique: false });
           recLogStore.createIndex("byDate", "recommendedAt", { unique: false });
+        }
+
+        // favorites ストア
+        if (!db.objectStoreNames.contains(STORE_NAMES.favorites)) {
+          const favoritesStore = db.createObjectStore(STORE_NAMES.favorites, {
+            keyPath: "id",
+          });
+          favoritesStore.createIndex("byVisitor", "visitorId", { unique: false });
         }
       };
     });
@@ -314,6 +324,64 @@ export class IndexedDBStorage implements PreferenceStorage {
    */
   async getArticleTags(_articleId: string): Promise<string[] | null> {
     return null;
+  }
+
+  /**
+   * お気に入り一覧を取得
+   */
+  async getFavorites(visitorId: string): Promise<Favorite[]> {
+    return this.withStore(STORE_NAMES.favorites, "readonly", (store) => {
+      return new Promise((resolve, reject) => {
+        const index = store.index("byVisitor");
+        const request = index.getAll(visitorId);
+
+        request.onsuccess = () => {
+          const results = request.result as Favorite[];
+          // addedAtで降順ソート（最新が先）
+          results.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+          resolve(results);
+        };
+        request.onerror = () => {
+          reject(request.error);
+        };
+      });
+    });
+  }
+
+  /**
+   * お気に入りを追加（同じ記事への既存お気に入りは上書き）
+   */
+  async addFavorite(favorite: Favorite): Promise<void> {
+    return this.withStore(STORE_NAMES.favorites, "readwrite", (store) => {
+      return new Promise((resolve, reject) => {
+        // putを使用してupsert（存在する場合は更新）
+        const request = store.put(favorite);
+        request.onsuccess = () => {
+          resolve();
+        };
+        request.onerror = () => {
+          reject(request.error);
+        };
+      });
+    });
+  }
+
+  /**
+   * お気に入りを解除
+   */
+  async removeFavorite(visitorId: string, articleId: string): Promise<void> {
+    return this.withStore(STORE_NAMES.favorites, "readwrite", (store) => {
+      return new Promise((resolve, reject) => {
+        const id = `${visitorId}_${articleId}`;
+        const request = store.delete(id);
+        request.onsuccess = () => {
+          resolve();
+        };
+        request.onerror = () => {
+          reject(request.error);
+        };
+      });
+    });
   }
 
   /**

--- a/packages/shared/src/storage/types.test.ts
+++ b/packages/shared/src/storage/types.test.ts
@@ -32,6 +32,9 @@ describe("004-01-01: ストレージ抽象化レイヤー", () => {
         addRecommendationLog: async (_log) => {},
         getDislikedArticleIds: async (_visitorId) => [],
         getArticleTags: async (_articleId) => null,
+        getFavorites: async (_visitorId) => [],
+        addFavorite: async (_favorite) => {},
+        removeFavorite: async (_visitorId, _articleId) => {},
       };
 
       expect(mockStorage).toBeDefined();

--- a/packages/shared/src/storage/types.ts
+++ b/packages/shared/src/storage/types.ts
@@ -86,6 +86,26 @@ export interface PreferenceStorage {
    * @returns タグの配列。記事が存在しない場合はnull
    */
   getArticleTags(articleId: string): Promise<string[] | null>;
+
+  /**
+   * お気に入り一覧を取得
+   * @param visitorId 訪問者ID
+   * @returns お気に入りの配列（追加日時降順）
+   */
+  getFavorites(visitorId: string): Promise<Favorite[]>;
+
+  /**
+   * お気に入りを追加
+   * @param favorite 追加するお気に入り
+   */
+  addFavorite(favorite: Favorite): Promise<void>;
+
+  /**
+   * お気に入りを解除
+   * @param visitorId 訪問者ID
+   * @param articleId 記事ID
+   */
+  removeFavorite(visitorId: string, articleId: string): Promise<void>;
 }
 
 /**
@@ -205,4 +225,23 @@ export interface RecommendationLog {
 
   /** ユーザーがクリックしたか */
   clicked: boolean;
+}
+
+/**
+ * お気に入り
+ *
+ * ユーザーが保存したお気に入り記事。Likeより強い正シグナル（重み2.0）。
+ */
+export interface Favorite {
+  /** 複合ID: `${visitorId}_${articleId}` */
+  id: string;
+
+  /** 訪問者ID */
+  visitorId: string;
+
+  /** 記事ID */
+  articleId: string;
+
+  /** 追加日時（ISO 8601形式） */
+  addedAt: string;
 }

--- a/specs/004-recommend/004-01-recommend-foundation/004-01-06.md
+++ b/specs/004-recommend/004-01-recommend-foundation/004-01-06.md
@@ -6,7 +6,7 @@
 
 ## ステータス
 
-- **status**: pending
+- **status**: completed
 
 ## ユーザーストーリー
 
@@ -16,22 +16,22 @@
 
 ## Acceptance Criteria（EARS記法）
 
-- [ ] WHEN ユーザーが記事をお気に入りに追加した際
+- [x] WHEN ユーザーが記事をお気に入りに追加した際
       THEN Favoriteレコードがストレージに保存される
       AND 嗜好ベクトル計算時にLikeより強い重み（2.0）で反映される
 
-- [ ] WHEN ユーザーがお気に入り一覧を取得する際
+- [x] WHEN ユーザーがお気に入り一覧を取得する際
       THEN 保存した全てのお気に入り記事が返される
       AND 追加日時の降順でソートされる
 
-- [ ] WHEN ユーザーがお気に入りを解除した際
+- [x] WHEN ユーザーがお気に入りを解除した際
       THEN Favoriteレコードがストレージから削除される
       AND 次回の嗜好ベクトル計算から除外される
 
-- [ ] WHEN 同じ記事を再度お気に入りに追加した際
+- [x] WHEN 同じ記事を再度お気に入りに追加した際
       THEN 重複エラーにならず、追加日時が更新される
 
-- [ ] WHERE お気に入り機能
+- [x] WHERE お気に入り機能
       THE SYSTEM SHALL PreferenceStorageインターフェースに以下を追加する: - getFavorites(visitorId): お気に入り一覧取得 - addFavorite(favorite): お気に入り追加 - removeFavorite(visitorId, articleId): お気に入り解除
 
 ## 技術設計
@@ -153,17 +153,18 @@ flowchart TB
 
 ## テストケース
 
-- [ ] お気に入りを追加すると保存される
-- [ ] お気に入り一覧が追加日時降順で返される
-- [ ] お気に入りを解除すると削除される
-- [ ] 同じ記事を再度追加すると追加日時が更新される
-- [ ] 存在しないお気に入りを解除してもエラーにならない
+- [x] お気に入りを追加すると保存される
+- [x] お気に入り一覧が追加日時降順で返される
+- [x] お気に入りを解除すると削除される
+- [x] 同じ記事を再度追加すると追加日時が更新される
+- [x] 存在しないお気に入りを解除してもエラーにならない
 
 ## 成果物
 
 - `packages/shared/src/storage/types.ts`（Favorite型追加）
 - `packages/shared/src/storage/indexed-db.ts`（お気に入りメソッド追加）
-- `packages/shared/src/storage/__tests__/indexed-db-favorite.test.ts`
+- `packages/shared/src/storage/indexed-db-favorite.test.ts`
+- `packages/shared/src/storage/composite-storage.ts`（お気に入りメソッド追加）
 
 ## 依存関係
 

--- a/specs/004-recommend/004-01-recommend-foundation/subtask-list.md
+++ b/specs/004-recommend/004-01-recommend-foundation/subtask-list.md
@@ -7,7 +7,7 @@
 | [004-01-03](./004-01-03.md) | 嗜好プロファイル計算     | PreferenceProfilerクラス          | completed  | 004-01-02 |
 | [004-01-04](./004-01-04.md) | 記事タグ取得実装         | SupabaseTagStorage + Composite    | completed  | 004-01-01 |
 | [004-01-05](./004-01-05.md) | 嗜好ベクトル計算         | preferenceEmbedding計算           | pending    | 004-01-03 |
-| [004-01-06](./004-01-06.md) | お気に入り機能           | Favorite保存・取得                | pending    | 004-01-02 |
+| [004-01-06](./004-01-06.md) | お気に入り機能           | Favorite保存・取得                | completed  | 004-01-02 |
 
 ## 依存関係図
 


### PR DESCRIPTION
- Favorite型をtypes.tsに追加
- PreferenceStorageインターフェースにgetFavorites, addFavorite, removeFavoriteを追加
- IndexedDBStorageにお気に入り機能を実装（DBバージョン2）
- CompositeStorageにお気に入りメソッドの委譲を追加
- お気に入り機能のテストファイルを追加（16テスト）
- 既存テストファイルのモックを更新

AC:
- お気に入り追加でFavoriteレコード保存
- お気に入り一覧が追加日時降順で返される
- お気に入り解除でFavoriteレコード削除
- 重複追加は追加日時更新（エラーなし）
- PreferenceStorageインターフェース拡張