### PR TITLE
fix(pipeline): 外部API呼び出しにタイムアウト設定を追加

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
   pipeline:
     name: Run Data Pipeline
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
       - name: Checkout repository

--- a/packages/pipeline/scripts/run-pipeline.ts
+++ b/packages/pipeline/scripts/run-pipeline.ts
@@ -136,6 +136,8 @@ async function main(): Promise<void> {
   // OpenAIクライアント初期化
   const openai = new OpenAI({
     apiKey: env.OPENAI_API_KEY,
+    timeout: 60 * 1000, // 60秒タイムアウト
+    maxRetries: 2, // リトライ回数を制限
   });
 
   // 依存関係の初期化

--- a/packages/pipeline/src/crawler/english-crawler.ts
+++ b/packages/pipeline/src/crawler/english-crawler.ts
@@ -8,6 +8,26 @@ import type { ArticleContent, ArticleIndex, BranchCrawler } from "./types";
 
 const BASE_URL = "https://scp-data.tedivm.com/data/scp/items";
 
+/** Fetch タイムアウト（ミリ秒） */
+const FETCH_TIMEOUT_MS = 30000;
+
+/**
+ * タイムアウト付きfetchを実行する
+ */
+async function fetchWithTimeout(url: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 interface ScpIndexItem {
   link: string;
   title: string;
@@ -61,7 +81,7 @@ export class EnglishCrawler implements BranchCrawler {
       return this.indexCache;
     }
 
-    const response = await fetch(`${BASE_URL}/index.json`);
+    const response = await fetchWithTimeout(`${BASE_URL}/index.json`);
     if (!response.ok) {
       throw new Error(`インデックス取得に失敗: ${String(response.status)}`);
     }
@@ -77,7 +97,7 @@ export class EnglishCrawler implements BranchCrawler {
       return cached;
     }
 
-    const response = await fetch(`${BASE_URL}/content_${seriesName}.json`);
+    const response = await fetchWithTimeout(`${BASE_URL}/content_${seriesName}.json`);
     if (!response.ok) {
       throw new Error(`${seriesName}の取得に失敗: ${String(response.status)}`);
     }


### PR DESCRIPTION
パイプラインが途中でキャンセルされる原因を修正:
- Fetch APIにAbortControllerを使用した30秒タイムアウトを追加
- OpenAIクライアントに60秒タイムアウトとリトライ制限を設定
- GitHub Actionsのtimeout-minutesを60分から120分に延長