### PR TITLE
fix(pipeline): embedding処理のタイムアウト問題を修正

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -44,7 +44,7 @@ jobs:
   pipeline:
     name: Run Data Pipeline
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     steps:
       - name: Checkout repository

--- a/packages/pipeline/src/processing/batch-embedding.ts
+++ b/packages/pipeline/src/processing/batch-embedding.ts
@@ -16,7 +16,7 @@ export const COST_PER_MILLION_TOKENS = 0.02;
 const MAX_CONTENT_LENGTH = 30000;
 
 /** デフォルトのバッチサイズ */
-const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_BATCH_SIZE = 50;
 
 /** バッチ間の遅延（ミリ秒） */
 const BATCH_DELAY_MS = 1000;
@@ -43,7 +43,7 @@ export interface DbArticle {
 
 /** バッチ処理オプション */
 export interface BatchEmbeddingOptions {
-  /** バッチサイズ（デフォルト: 10） */
+  /** バッチサイズ（デフォルト: 50） */
   batchSize?: number;
   /** コスト上限（USD） */
   costLimit?: number;
@@ -150,8 +150,9 @@ export class BatchEmbeddingProcessor {
 
   /**
    * 未処理記事を取得する
+   * @param limit 取得上限（デフォルト: 2000件、1回のGitHub Actions実行で処理可能な件数）
    */
-  async getPendingArticles(limit = 10000): Promise<DbArticle[]> {
+  async getPendingArticles(limit = 2000): Promise<DbArticle[]> {
     const { data, error } = await this.supabase
       .from("scp_articles")
       .select("*")


### PR DESCRIPTION
GitHub Actionsのタイムアウト（120分）に対して処理時間が超過していた問題を修正。

変更内容:
- バッチサイズを10→50に増加（処理効率向上）
- 1回の実行で取得するpending件数を10000→2000に制限
- GitHub Actionsタイムアウトを120→180分に延長

これにより:
- 2000件を約40バッチで処理可能
- 1回の実行で確実に完了
- 4回程度の実行で全7282件を処理可能