### PR TITLE
fix(pipeline): enhance CSS removal logic to resolve embedding errors

### DIFF
--- a/packages/pipeline/src/crawler/fetch-scp.ts
+++ b/packages/pipeline/src/crawler/fetch-scp.ts
@@ -64,20 +64,42 @@ const fetchSeriesContent = async (seriesFile: string): Promise<Record<string, Sc
 
 /**
  * Extract plain text from HTML content
+ * CSSコード、スクリプト、HTMLタグを除去してプレーンテキストを抽出
  */
-const htmlToPlainText = (html: string): string =>
-  html
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, " ")
-    .trim();
+const htmlToPlainText = (html: string): string => {
+  let text = html;
+
+  // 1. style/scriptタグとその内容を除去
+  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, " ");
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, " ");
+
+  // 2. HTMLタグを除去
+  text = text.replace(/<[^>]+>/g, " ");
+
+  // 3. CSSコメントを除去
+  text = text.replace(/\/\*[\s\S]*?\*\//g, " ");
+
+  // 4. CSSブロック（{...}）を除去（ネスト対応で複数回実行）
+  for (let i = 0; i < 3; i++) {
+    text = text.replace(/\{[^{}]*\}/g, " ");
+  }
+
+  // 5. @ルール（@media, @import等）を除去
+  text = text.replace(/@[\w-]+[^;]*;/g, " ");
+
+  // 6. HTMLエンティティをデコード
+  text = text.replace(/&nbsp;/g, " ");
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+
+  // 7. 空白を正規化
+  text = text.replace(/\s+/g, " ").trim();
+
+  return text;
+};
 
 /**
  * Filter and sort articles by rating

--- a/packages/pipeline/src/processing/batch-embedding.ts
+++ b/packages/pipeline/src/processing/batch-embedding.ts
@@ -95,14 +95,40 @@ export interface ProcessorOptions {
 
 /**
  * コンテンツを前処理する
+ * - CSSコード（ブロック、セレクタ、@ルール）を除去
  * - HTMLタグを除去
  * - 空白を正規化
  * - 最大長でトランケート
  */
 function preprocessContent(content: string): string {
-  const withoutTags = content.replace(/<[^>]*>/g, "");
-  const normalized = withoutTags.replace(/\s+/g, " ").trim();
-  return normalized.slice(0, MAX_CONTENT_LENGTH);
+  let processed = content;
+
+  // 1. CSSコメントを除去
+  processed = processed.replace(/\/\*[\s\S]*?\*\//g, " ");
+
+  // 2. CSSブロックを除去（{...} で囲まれたスタイル定義）
+  // ネストに対応するため複数回実行
+  for (let i = 0; i < 3; i++) {
+    processed = processed.replace(/\{[^{}]*\}/g, " ");
+  }
+
+  // 3. @ルール（@media, @import, @keyframes等）を除去
+  processed = processed.replace(/@[\w-]+[^;]*;/g, " ");
+
+  // 4. CSSセレクタパターンを除去（.class, #id, element::pseudo等）
+  processed = processed.replace(/[.#][\w-]+(?:\s*,\s*[.#][\w-]+)*/g, " ");
+
+  // 5. CSS擬似要素・擬似クラスを除去
+  processed = processed.replace(/::?[\w-]+/g, " ");
+
+  // 6. HTMLタグを除去（念のため）
+  processed = processed.replace(/<[^>]*>/g, " ");
+
+  // 7. 空白を正規化
+  processed = processed.replace(/\s+/g, " ").trim();
+
+  // 8. 最大長でトランケート
+  return processed.slice(0, MAX_CONTENT_LENGTH);
 }
 
 /**

--- a/packages/shared/src/embedding/generate.ts
+++ b/packages/shared/src/embedding/generate.ts
@@ -51,19 +51,40 @@ export interface ScpArticle {
 
 /**
  * Preprocess content for embedding generation
+ * - Removes CSS code (blocks, selectors, @rules)
  * - Removes HTML tags
  * - Normalizes whitespace
  * - Truncates to max length
  */
 export function preprocessContent(content: string): string {
-  // Remove HTML tags
-  const withoutTags = content.replace(/<[^>]*>/g, "");
+  let processed = content;
 
-  // Normalize whitespace
-  const normalized = withoutTags.replace(/\s+/g, " ").trim();
+  // 1. Remove CSS comments
+  processed = processed.replace(/\/\*[\s\S]*?\*\//g, " ");
 
-  // Truncate to max length
-  return normalized.slice(0, MAX_CONTENT_LENGTH);
+  // 2. Remove CSS blocks ({...} style definitions)
+  // Run multiple times to handle nesting
+  for (let i = 0; i < 3; i++) {
+    processed = processed.replace(/\{[^{}]*\}/g, " ");
+  }
+
+  // 3. Remove @rules (@media, @import, @keyframes, etc.)
+  processed = processed.replace(/@[\w-]+[^;]*;/g, " ");
+
+  // 4. Remove CSS selector patterns (.class, #id, element::pseudo, etc.)
+  processed = processed.replace(/[.#][\w-]+(?:\s*,\s*[.#][\w-]+)*/g, " ");
+
+  // 5. Remove CSS pseudo-elements and pseudo-classes
+  processed = processed.replace(/::?[\w-]+/g, " ");
+
+  // 6. Remove HTML tags (just in case)
+  processed = processed.replace(/<[^>]*>/g, " ");
+
+  // 7. Normalize whitespace
+  processed = processed.replace(/\s+/g, " ").trim();
+
+  // 8. Truncate to max length
+  return processed.slice(0, MAX_CONTENT_LENGTH);
 }
 
 /**


### PR DESCRIPTION
embedding_status: "error"となる記事の原因調査の結果、SCP Wikiのテーマ
（Foxtrot Sigma-9等）に含まれるCSSコードがコンテンツに混入し、
embeddingの品質を低下させていることが判明。

変更内容:
- preprocessContent関数にCSS除去ロジックを追加
  - CSSコメント除去 (/* ... */)
  - CSSブロック除去 ({...})
  - @ルール除去 (@media, @import等)
  - CSSセレクタ除去 (.class, #id等)
  - 擬似要素・擬似クラス除去 (::before, :hover等)
- htmlToPlainText関数にも同様のCSS除去を追加

これにより、エラー記事を再処理することで正常にembeddingが生成される。

https://claude.ai/code/session_016mqmFv688961MdZYRCWUTY