### PR TITLE
feat(api-server): 005-04-01 articles repository/serviceを実装

### DIFF
--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -18,6 +18,7 @@
     "@recommend-scp/shared": "workspace:*",
     "@supabase/supabase-js": "^2.49.4",
     "hono": "^4.7.10",
+    "openai": "^4.77.0",
     "pino": "^10.2.0",
     "zod": "^3.25.2"
   },

--- a/apps/api-server/src/domains/articles/__dev__/repository.test.ts
+++ b/apps/api-server/src/domains/articles/__dev__/repository.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @file ArticlesRepository テスト
+ * @description articlesドメインのDB操作層テスト
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ArticlesRepository } from "../repository";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+describe("ArticlesRepository", () => {
+  let repository: ArticlesRepository;
+  let mockSupabase: {
+    rpc: ReturnType<typeof vi.fn>;
+    from: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = {
+      rpc: vi.fn(),
+      from: vi.fn(),
+    };
+    repository = new ArticlesRepository(mockSupabase as unknown as SupabaseClient);
+  });
+
+  describe("インスタンス化", () => {
+    it("インスタンス化時にsearchByEmbeddingメソッドを提供する", () => {
+      expect(repository.searchByEmbedding).toBeDefined();
+      expect(typeof repository.searchByEmbedding).toBe("function");
+    });
+
+    it("インスタンス化時にgetArticleByIdメソッドを提供する", () => {
+      expect(repository.getArticleById).toBeDefined();
+      expect(typeof repository.getArticleById).toBe("function");
+    });
+  });
+
+  describe("searchByEmbedding", () => {
+    it("ベクトル検索結果を取得できる", async () => {
+      const mockResults = [
+        { id: "scp-173", title: "The Sculpture", similarity: 0.95 },
+        { id: "scp-096", title: "The Shy Guy", similarity: 0.87 },
+      ];
+      mockSupabase.rpc.mockResolvedValue({ data: mockResults, error: null });
+
+      const result = await repository.searchByEmbedding([0.1, 0.2, 0.3]);
+
+      expect(result).toEqual(mockResults);
+      expect(mockSupabase.rpc).toHaveBeenCalledWith("search_articles_by_embedding", {
+        query_vector: [0.1, 0.2, 0.3],
+        exclude_ids: [],
+        match_count: 10,
+      });
+    });
+
+    it("limitを指定して検索できる", async () => {
+      mockSupabase.rpc.mockResolvedValue({ data: [], error: null });
+
+      await repository.searchByEmbedding([0.1, 0.2], { limit: 5 });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        "search_articles_by_embedding",
+        expect.objectContaining({ match_count: 5 })
+      );
+    });
+
+    it("excludeIdsを指定して検索できる", async () => {
+      mockSupabase.rpc.mockResolvedValue({ data: [], error: null });
+
+      await repository.searchByEmbedding([0.1, 0.2], {
+        excludeIds: ["scp-173", "scp-096"],
+      });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        "search_articles_by_embedding",
+        expect.objectContaining({ exclude_ids: ["scp-173", "scp-096"] })
+      );
+    });
+
+    it("dataがnullの場合、空配列を返す", async () => {
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const result = await repository.searchByEmbedding([0.1, 0.2]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("RPC関数エラー時に例外をthrowする", async () => {
+      const mockError = { code: "ERROR", message: "RPC function not found" };
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: mockError });
+
+      await expect(repository.searchByEmbedding([0.1, 0.2])).rejects.toEqual(mockError);
+    });
+  });
+
+  describe("getArticleById", () => {
+    it("記事詳細を取得できる", async () => {
+      const mockArticle = {
+        id: "scp-173",
+        title: "The Sculpture",
+        url: "https://scp-wiki.wikidot.com/scp-173",
+        tags: ["safe", "sculpture"],
+        rating: 1500,
+      };
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockArticle, error: null }),
+      };
+      mockSupabase.from.mockReturnValue(mockChain);
+
+      const result = await repository.getArticleById("scp-173");
+
+      expect(result).toEqual(mockArticle);
+      expect(mockSupabase.from).toHaveBeenCalledWith("scp_articles");
+      expect(mockChain.select).toHaveBeenCalledWith("id, title, url, tags, rating");
+      expect(mockChain.eq).toHaveBeenCalledWith("id", "scp-173");
+    });
+
+    it("存在しない記事IDでnullを返す", async () => {
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { code: "PGRST116" } }),
+      };
+      mockSupabase.from.mockReturnValue(mockChain);
+
+      const result = await repository.getArticleById("nonexistent");
+
+      expect(result).toBeNull();
+    });
+
+    it("ratingがnullの記事を取得できる", async () => {
+      const mockArticle = {
+        id: "scp-unknown",
+        title: "Unknown",
+        url: "https://example.com",
+        tags: [],
+        rating: null,
+      };
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockArticle, error: null }),
+      };
+      mockSupabase.from.mockReturnValue(mockChain);
+
+      const result = await repository.getArticleById("scp-unknown");
+
+      expect(result?.rating).toBeNull();
+    });
+
+    it("PGRST116以外のDBエラー時に例外をthrowする", async () => {
+      const mockError = { code: "PGRST500", message: "DB Error" };
+      const mockChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: mockError }),
+      };
+      mockSupabase.from.mockReturnValue(mockChain);
+
+      await expect(repository.getArticleById("test")).rejects.toEqual(mockError);
+    });
+  });
+});

--- a/apps/api-server/src/domains/articles/__dev__/service.test.ts
+++ b/apps/api-server/src/domains/articles/__dev__/service.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @file ArticlesService テスト
+ * @description articlesドメインのビジネスロジック層テスト
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ArticlesService } from "../service";
+import type { ArticlesRepository } from "../repository";
+import { createEmbedding } from "../../../lib/openai";
+
+// openaiモジュールをモック
+vi.mock("../../../lib/openai", () => ({
+  createEmbedding: vi.fn(),
+}));
+
+// モックされた関数への参照を取得
+const mockCreateEmbedding = vi.mocked(createEmbedding);
+
+describe("ArticlesService", () => {
+  let service: ArticlesService;
+  let mockRepository: {
+    searchByEmbedding: ReturnType<typeof vi.fn>;
+    getArticleById: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRepository = {
+      searchByEmbedding: vi.fn(),
+      getArticleById: vi.fn(),
+    };
+    service = new ArticlesService(mockRepository as unknown as ArticlesRepository);
+  });
+
+  describe("インスタンス化", () => {
+    it("インスタンス化時にsearchArticlesメソッドを提供する", () => {
+      expect(service.searchArticles).toBeDefined();
+      expect(typeof service.searchArticles).toBe("function");
+    });
+  });
+
+  describe("searchArticles", () => {
+    it("有効なクエリでEmbedding APIを呼び出す", async () => {
+      const mockVector = [0.1, 0.2, 0.3];
+      mockCreateEmbedding.mockResolvedValue(mockVector);
+      mockRepository.searchByEmbedding.mockResolvedValue([]);
+
+      await service.searchArticles("ホラー系のscp");
+
+      expect(mockCreateEmbedding).toHaveBeenCalledWith("ホラー系のscp");
+    });
+
+    it("ベクトル検索RPC関数を呼び出す", async () => {
+      const mockVector = [0.1, 0.2, 0.3];
+      mockCreateEmbedding.mockResolvedValue(mockVector);
+      mockRepository.searchByEmbedding.mockResolvedValue([]);
+
+      await service.searchArticles("test query");
+
+      expect(mockRepository.searchByEmbedding).toHaveBeenCalledWith(mockVector, {
+        limit: 10,
+      });
+    });
+
+    it("類似度降順でソートされた結果を返す", async () => {
+      const mockResults = [
+        { id: "scp-173", title: "The Sculpture", similarity: 0.95 },
+        { id: "scp-096", title: "The Shy Guy", similarity: 0.87 },
+        { id: "scp-682", title: "Hard-to-Destroy Reptile", similarity: 0.75 },
+      ];
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      mockRepository.searchByEmbedding.mockResolvedValue(mockResults);
+
+      const result = await service.searchArticles("test");
+
+      expect(result.articles[0].similarity).toBe(0.95);
+      expect(result.articles[1].similarity).toBe(0.87);
+      expect(result.articles[2].similarity).toBe(0.75);
+      expect(result.articles[0].similarity).toBeGreaterThanOrEqual(result.articles[1].similarity);
+    });
+
+    it("検索結果のレスポンス形式が正しい", async () => {
+      const mockResults = [{ id: "scp-173", title: "The Sculpture", similarity: 0.95 }];
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      mockRepository.searchByEmbedding.mockResolvedValue(mockResults);
+
+      const result = await service.searchArticles("horror");
+
+      expect(result).toEqual({
+        articles: [{ id: "scp-173", title: "The Sculpture", similarity: 0.95 }],
+        total: 1,
+        query: "horror",
+      });
+    });
+
+    it("limitオプションが指定された場合、repositoryに渡される", async () => {
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      mockRepository.searchByEmbedding.mockResolvedValue([]);
+
+      await service.searchArticles("test", { limit: 5 });
+
+      expect(mockRepository.searchByEmbedding).toHaveBeenCalledWith([0.1, 0.2], {
+        limit: 5,
+      });
+    });
+
+    it("検索結果が0件の場合、空配列を返す", async () => {
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      mockRepository.searchByEmbedding.mockResolvedValue([]);
+
+      const result = await service.searchArticles("nonexistent");
+
+      expect(result.articles).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("多言語対応", () => {
+    it("日本語クエリで検索できる", async () => {
+      const mockResults = [{ id: "scp-173", title: "The Sculpture", similarity: 0.9 }];
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      mockRepository.searchByEmbedding.mockResolvedValue(mockResults);
+
+      const result = await service.searchArticles("ホラー系のscp");
+
+      expect(result.articles).toHaveLength(1);
+      expect(mockCreateEmbedding).toHaveBeenCalledWith("ホラー系のscp");
+    });
+
+    it("英語クエリで検索できる", async () => {
+      const mockResults = [{ id: "scp-096", title: "The Shy Guy", similarity: 0.85 }];
+      mockCreateEmbedding.mockResolvedValue([0.3, 0.4]);
+      mockRepository.searchByEmbedding.mockResolvedValue(mockResults);
+
+      const result = await service.searchArticles("horror scp");
+
+      expect(result.articles).toHaveLength(1);
+      expect(mockCreateEmbedding).toHaveBeenCalledWith("horror scp");
+    });
+
+    it("日英混在テキストを正常に処理する", async () => {
+      mockCreateEmbedding.mockResolvedValue([0.5, 0.6]);
+      mockRepository.searchByEmbedding.mockResolvedValue([]);
+
+      const result = await service.searchArticles("ホラー horror 怖い scary");
+
+      expect(result.articles).toEqual([]);
+      expect(mockCreateEmbedding).toHaveBeenCalledWith("ホラー horror 怖い scary");
+    });
+  });
+
+  describe("異常系", () => {
+    it("OpenAI APIエラー時に例外をthrowする", async () => {
+      const apiError = new Error("OpenAI API rate limit exceeded");
+      mockCreateEmbedding.mockRejectedValue(apiError);
+
+      await expect(service.searchArticles("test")).rejects.toThrow(
+        "OpenAI API rate limit exceeded"
+      );
+    });
+
+    it("RPC関数エラー時に例外をthrowする", async () => {
+      mockCreateEmbedding.mockResolvedValue([0.1, 0.2]);
+      const dbError = new Error("RPC function not found");
+      mockRepository.searchByEmbedding.mockRejectedValue(dbError);
+
+      await expect(service.searchArticles("test")).rejects.toThrow("RPC function not found");
+    });
+  });
+});

--- a/apps/api-server/src/domains/articles/repository.ts
+++ b/apps/api-server/src/domains/articles/repository.ts
@@ -1,0 +1,102 @@
+/**
+ * @file ArticlesRepository
+ * @description articlesドメインのDB操作層
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { VectorSearchClientResult } from "@recommend-scp/shared/search";
+
+/**
+ * Supabaseエラー型
+ */
+interface SupabaseError extends Error {
+  code?: string;
+}
+
+/**
+ * Supabase RPC/クエリ戻り値の型定義
+ */
+interface SupabaseResponse<T> {
+  data: T | null;
+  error: SupabaseError | null;
+}
+
+/**
+ * 記事詳細
+ */
+export interface ArticleDetail {
+  /** 記事ID */
+  id: string;
+  /** タイトル */
+  title: string;
+  /** URL */
+  url: string;
+  /** タグ一覧 */
+  tags: string[];
+  /** 評価スコア */
+  rating: number | null;
+}
+
+/**
+ * 検索オプション
+ */
+export interface SearchOptions {
+  /** 取得件数上限（デフォルト: 10） */
+  limit?: number;
+  /** 除外する記事ID */
+  excludeIds?: string[];
+}
+
+/**
+ * ArticlesRepository
+ *
+ * 記事のDB操作を担当する。
+ * pgvector RPC関数を使用したセマンティック検索を提供。
+ */
+export class ArticlesRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  /**
+   * ベクトル類似度検索
+   *
+   * クエリベクトルとのコサイン類似度が高い記事を検索する。
+   * 結果は類似度降順でソートされる。
+   *
+   * @param queryVector - クエリベクトル
+   * @param options - 検索オプション
+   * @returns 検索結果（類似度降順）
+   */
+  searchByEmbedding = async (
+    queryVector: number[],
+    options: SearchOptions = {}
+  ): Promise<VectorSearchClientResult[]> => {
+    const response = (await this.supabase.rpc("search_articles_by_embedding", {
+      query_vector: queryVector,
+      exclude_ids: options.excludeIds ?? [],
+      match_count: options.limit ?? 10,
+    })) as unknown as SupabaseResponse<VectorSearchClientResult[]>;
+
+    if (response.error !== null) throw response.error;
+    return response.data ?? [];
+  };
+
+  /**
+   * 記事IDで記事詳細を取得
+   *
+   * @param id - 記事ID
+   * @returns 記事詳細。存在しない場合はnull
+   */
+  getArticleById = async (id: string): Promise<ArticleDetail | null> => {
+    const response = (await this.supabase
+      .from("scp_articles")
+      .select("id, title, url, tags, rating")
+      .eq("id", id)
+      .single()) as unknown as SupabaseResponse<ArticleDetail>;
+
+    // PGRST116: 行が見つからない場合のエラーコード
+    if (response.error?.code === "PGRST116") return null;
+    if (response.error !== null) throw response.error;
+    return response.data;
+  };
+}

--- a/apps/api-server/src/domains/articles/service.ts
+++ b/apps/api-server/src/domains/articles/service.ts
@@ -1,0 +1,88 @@
+/**
+ * @file ArticlesService
+ * @description articlesドメインのビジネスロジック層
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import type { ArticlesRepository } from "./repository";
+import { createEmbedding } from "../../lib/openai";
+
+/**
+ * 記事検索結果の1件
+ */
+export interface SearchArticle {
+  /** 記事ID */
+  id: string;
+  /** タイトル */
+  title: string;
+  /** 類似度スコア（0〜1） */
+  similarity: number;
+  /** タグ一覧（オプション） */
+  tags?: string[];
+}
+
+/**
+ * 記事検索結果
+ */
+export interface SearchArticlesResult {
+  /** 検索結果の記事一覧 */
+  articles: SearchArticle[];
+  /** 検索結果の総件数 */
+  total: number;
+  /** 検索クエリ */
+  query: string;
+}
+
+/**
+ * 検索オプション
+ */
+export interface SearchArticlesOptions {
+  /** 取得件数上限（デフォルト: 10） */
+  limit?: number;
+}
+
+/**
+ * ArticlesService
+ *
+ * 記事のセマンティック検索を提供する。
+ * クエリテキストをEmbeddingに変換し、ベクトル類似度検索を実行する。
+ */
+export class ArticlesService {
+  constructor(private readonly repository: ArticlesRepository) {}
+
+  /**
+   * テキストクエリによるセマンティック検索
+   *
+   * 1. クエリをOpenAI Embedding APIでベクトル化
+   * 2. pgvector RPC関数で類似記事を検索
+   * 3. 類似度降順でソートされた結果を返す
+   *
+   * @param query - 検索クエリ（日本語・英語対応）
+   * @param options - 検索オプション
+   * @returns 検索結果
+   */
+  searchArticles = async (
+    query: string,
+    options: SearchArticlesOptions = {}
+  ): Promise<SearchArticlesResult> => {
+    // クエリをEmbeddingに変換
+    const queryVector = await createEmbedding(query);
+
+    // ベクトル検索
+    const results = await this.repository.searchByEmbedding(queryVector, {
+      limit: options.limit ?? 10,
+    });
+
+    return {
+      articles: results.map(
+        (r): SearchArticle => ({
+          id: r.id,
+          title: r.title,
+          similarity: r.similarity,
+        })
+      ),
+      total: results.length,
+      query,
+    };
+  };
+}

--- a/apps/api-server/src/lib/__dev__/openai.test.ts
+++ b/apps/api-server/src/lib/__dev__/openai.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @file createEmbedding テスト
+ * @description OpenAI Embedding API呼び出しのテスト
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// envモジュールをモック
+vi.mock("@recommend-scp/shared/lib/env", () => ({
+  env: {
+    OPENAI_API_KEY: "test-api-key",
+  },
+}));
+
+// モック用のcreate関数
+const mockCreate = vi.fn();
+
+// OpenAI モジュールをモック（class構文を使用）
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      embeddings = {
+        create: mockCreate,
+      };
+    },
+  };
+});
+
+describe("createEmbedding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // モジュールキャッシュをクリアして再インポート
+    vi.resetModules();
+  });
+
+  it("テキストからベクトルを取得できる", async () => {
+    const mockEmbedding = [0.1, 0.2, 0.3];
+    mockCreate.mockResolvedValue({
+      data: [{ embedding: mockEmbedding }],
+    });
+
+    // モジュールを再インポート
+    const { createEmbedding } = await import("../openai");
+    const result = await createEmbedding("test text");
+
+    expect(result).toEqual(mockEmbedding);
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: "text-embedding-3-small",
+      input: "test text",
+    });
+  });
+
+  it("日本語テキストを処理できる", async () => {
+    const mockEmbedding = [0.4, 0.5, 0.6];
+    mockCreate.mockResolvedValue({
+      data: [{ embedding: mockEmbedding }],
+    });
+
+    const { createEmbedding } = await import("../openai");
+    const result = await createEmbedding("ホラー系のscp");
+
+    expect(result).toEqual(mockEmbedding);
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: "text-embedding-3-small",
+      input: "ホラー系のscp",
+    });
+  });
+
+  it("空文字列でもベクトルを返す", async () => {
+    const mockEmbedding = [0.0, 0.0, 0.0];
+    mockCreate.mockResolvedValue({
+      data: [{ embedding: mockEmbedding }],
+    });
+
+    const { createEmbedding } = await import("../openai");
+    const result = await createEmbedding("");
+
+    expect(result).toEqual(mockEmbedding);
+  });
+
+  it("API認証エラー時に例外をthrowする", async () => {
+    const authError = new Error("Invalid API key");
+    mockCreate.mockRejectedValue(authError);
+
+    const { createEmbedding } = await import("../openai");
+    await expect(createEmbedding("test")).rejects.toThrow("Invalid API key");
+  });
+
+  it("レート制限エラー時に例外をthrowする", async () => {
+    const rateLimitError = new Error("Rate limit exceeded");
+    mockCreate.mockRejectedValue(rateLimitError);
+
+    const { createEmbedding } = await import("../openai");
+    await expect(createEmbedding("test")).rejects.toThrow("Rate limit exceeded");
+  });
+});

--- a/apps/api-server/src/lib/openai.ts
+++ b/apps/api-server/src/lib/openai.ts
@@ -1,0 +1,37 @@
+/**
+ * @file OpenAI Embedding ユーティリティ
+ * @description テキストクエリをEmbeddingベクトルに変換する
+ * @see specs/005-backend-api/005-04-articles-api/005-04-01.md
+ */
+
+import OpenAI from "openai";
+import { env } from "@recommend-scp/shared/lib/env";
+
+/** OpenAIクライアント（シングルトン） */
+let openaiClient: OpenAI | null = null;
+
+/**
+ * OpenAIクライアントを取得（遅延初期化）
+ */
+const getOpenAIClient = (): OpenAI => {
+  openaiClient ??= new OpenAI({ apiKey: env.OPENAI_API_KEY });
+  return openaiClient;
+};
+
+/**
+ * テキストをEmbeddingベクトルに変換
+ *
+ * @param text - 変換対象のテキスト（日本語・英語対応）
+ * @returns 1536次元のEmbeddingベクトル
+ * @throws OpenAI APIエラー（認証エラー、レート制限等）
+ */
+export const createEmbedding = async (text: string): Promise<number[]> => {
+  const openai = getOpenAIClient();
+
+  const response = await openai.embeddings.create({
+    model: "text-embedding-3-small",
+    input: text,
+  });
+
+  return response.data[0].embedding;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.11.5
+      openai:
+        specifier: ^4.77.0
+        version: 4.104.0(ws@8.18.3)(zod@3.25.76)
       pino:
         specifier: ^10.2.0
         version: 10.2.0

--- a/specs/005-backend-api/005-04-articles-api/005-04-01.md
+++ b/specs/005-backend-api/005-04-articles-api/005-04-01.md
@@ -24,7 +24,7 @@ SQLの`LIKE`や全文検索ではなく、Embeddingによる意味的類似度�
 
 ## ステータス
 
-- **status**: planned
+- **status**: completed
 
 ## ユーザーストーリー
 
@@ -34,19 +34,19 @@ SQLの`LIKE`や全文検索ではなく、Embeddingによる意味的類似度�
 
 ## Acceptance Criteria（EARS記法）
 
-- [ ] WHEN ArticlesRepositoryをインスタンス化した際
+- [x] WHEN ArticlesRepositoryをインスタンス化した際
       THEN searchByEmbedding, getArticleByIdメソッドを提供する
 
-- [ ] WHEN ArticlesServiceをインスタンス化した際
+- [x] WHEN ArticlesServiceをインスタンス化した際
       THEN searchArticlesメソッドを提供する
 
-- [ ] WHEN searchArticles を呼び出した際
+- [x] WHEN searchArticles を呼び出した際
       GIVEN 有効なクエリ文字列の場合
       THEN クエリをOpenAI Embedding API（text-embedding-3-small）でベクトル化する
       AND pgvector RPC関数で類似記事を検索する
       AND 類似度降順でソートされた結果を返す
 
-- [ ] WHEN searchArticles を呼び出した際
+- [x] WHEN searchArticles を呼び出した際
       GIVEN 日本語・英語どちらのクエリでも
       THEN 意味的に類似した記事を返す（多言語対応）
 
@@ -161,10 +161,10 @@ export async function createEmbedding(text: string): Promise<number[]> {
 
 ## テストケース
 
-- [ ] searchByEmbedding でベクトル検索結果を取得できる
-- [ ] searchArticles でテキストクエリから検索できる
-- [ ] getArticleById で記事詳細を取得できる
-- [ ] 存在しない記事IDでnullを返す
+- [x] searchByEmbedding でベクトル検索結果を取得できる
+- [x] searchArticles でテキストクエリから検索できる
+- [x] getArticleById で記事詳細を取得できる
+- [x] 存在しない記事IDでnullを返す
 
 ## 成果物
 

--- a/specs/005-backend-api/005-04-articles-api/subtask-list.md
+++ b/specs/005-backend-api/005-04-articles-api/subtask-list.md
@@ -2,5 +2,5 @@
 
 | ID                          | 名前                        | ステータス | 依存      |
 | --------------------------- | --------------------------- | ---------- | --------- |
-| [005-04-01](./005-04-01.md) | articles repository/service | planned    | 005-02-03 |
+| [005-04-01](./005-04-01.md) | articles repository/service | completed  | 005-02-03 |
 | [005-04-02](./005-04-02.md) | GET /articles/search        | planned    | 005-04-01 |


### PR DESCRIPTION
- ArticlesRepository: searchByEmbedding, getArticleByIdを実装
- ArticlesService: searchArticlesを実装
- lib/openai.ts: createEmbedding関数を実装
- 全テストケース実装（28件）

https://claude.ai/code/session_01Ao6pyaYQPUjJ78NW67yd67