### PR TITLE
feat(web): 006-01 オンボーディング画面を並行実装

### DIFF
--- a/apps/web/src/app/onboarding/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/__tests__/page.test.tsx
@@ -2,6 +2,42 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// api-clientをモック（他のimportより先に定義）
+vi.mock("@/shared/lib/api-client", () => ({
+  api: {
+    onboarding: {
+      packs: {
+        $get: vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              packs: [
+                {
+                  type: "horror",
+                  displayName: "ホラー好き",
+                  description: "恐怖と不気味さを求めるあなたに",
+                  primaryTags: ["ホラー", "恐怖", "不気味"],
+                },
+              ],
+            }),
+        }),
+      },
+      select: {
+        $post: vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        }),
+        custom: {
+          $post: vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ success: true }),
+          }),
+        },
+      },
+    },
+  },
+}));
+
 // モックを先に定義
 const mockRouterReplace = vi.fn();
 const mockRouterPush = vi.fn();
@@ -104,7 +140,7 @@ describe("OnboardingPage", () => {
       await user.click(packButton);
 
       // 戻るボタンをクリック
-      const backButton = screen.getByRole("button", { name: "戻る" });
+      const backButton = screen.getByRole("button", { name: /戻る/ });
       await user.click(backButton);
 
       // 選択画面に戻っていることを確認
@@ -133,7 +169,7 @@ describe("OnboardingPage", () => {
       await user.click(customButton);
 
       // 戻るボタンをクリック
-      const backButton = screen.getByRole("button", { name: "戻る" });
+      const backButton = screen.getByRole("button", { name: /戻る/ });
       await user.click(backButton);
 
       // 選択画面に戻っていることを確認

--- a/apps/web/src/app/onboarding/_components/PackSelector/PackCard.tsx
+++ b/apps/web/src/app/onboarding/_components/PackSelector/PackCard.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { StarterPackInfo } from "./usePackSelector";
+
+interface PackCardProps {
+  pack: StarterPackInfo;
+  isSelected: boolean;
+  onSelect: () => void;
+  disabled: boolean;
+}
+
+const icons: Record<string, string> = {
+  horror: "👻",
+  surreal: "🌀",
+  scientific: "🔬",
+  heartwarming: "💖",
+  mystery: "🔍",
+};
+
+export function PackCard({ pack, isSelected, onSelect, disabled }: PackCardProps) {
+  return (
+    <button
+      onClick={onSelect}
+      disabled={disabled}
+      className={`rounded-lg border-2 p-4 text-left transition-colors ${
+        isSelected
+          ? "border-blue-500 bg-blue-900/30"
+          : "border-gray-600 bg-gray-800 hover:border-gray-500"
+      } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-2xl">{icons[pack.type] || "📦"}</span>
+        <div>
+          <h3 className="font-bold text-white">{pack.displayName}</h3>
+          <p className="mt-1 text-sm text-gray-400">{pack.description}</p>
+          <div className="mt-2 flex gap-2">
+            {pack.primaryTags.slice(0, 3).map((tag) => (
+              <span key={tag} className="rounded bg-gray-700 px-2 py-1 text-xs text-gray-300">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/src/app/onboarding/_components/PackSelector/index.tsx
+++ b/apps/web/src/app/onboarding/_components/PackSelector/index.tsx
@@ -1,30 +1,133 @@
 "use client";
 
+import { usePackSelector } from "./usePackSelector";
+import { PackCard } from "./PackCard";
+
 export interface PackSelectorProps {
   visitorId: string;
   onComplete: () => void;
   onBack: () => void;
 }
 
-/**
- * パック選択コンポーネント（スタブ）
- *
- * 006-01-02 で実装予定
- */
-export function PackSelector({ onBack }: PackSelectorProps) {
+function PackSelectorSkeleton() {
   return (
-    <div
-      data-testid="pack-selector"
-      className="flex min-h-screen flex-col items-center justify-center p-4"
-    >
-      <h2 className="mb-8 text-2xl font-bold text-white">スターターパックを選択</h2>
-      <p className="mb-8 text-gray-300">（実装予定）</p>
-      <button
-        onClick={onBack}
-        className="rounded-lg border border-gray-600 bg-gray-800 px-4 py-2 text-white transition-colors hover:bg-gray-700"
-      >
-        戻る
-      </button>
+    <div className="flex min-h-screen flex-col p-4" data-testid="pack-selector-skeleton">
+      <div className="mb-6">
+        <div className="h-4 w-16 animate-pulse rounded bg-gray-700" />
+        <div className="mt-2 h-6 w-48 animate-pulse rounded bg-gray-700" />
+      </div>
+      <div className="flex flex-1 flex-col gap-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-gray-800" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ErrorStateProps {
+  message: string;
+  onRetry: () => void;
+  onBack: () => void;
+}
+
+function ErrorState({ message, onRetry, onBack }: ErrorStateProps) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-4 text-white">
+      <p className="mb-4 text-red-400">{message}</p>
+      <div className="flex gap-4">
+        <button onClick={onBack} className="rounded-lg bg-gray-700 px-4 py-2 hover:bg-gray-600">
+          戻る
+        </button>
+        <button onClick={onRetry} className="rounded-lg bg-blue-600 px-4 py-2 hover:bg-blue-500">
+          リトライ
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * パック選択コンポーネント
+ *
+ * スターターパックの一覧を表示し、ユーザーが選択できる
+ */
+export function PackSelector({ visitorId, onComplete, onBack }: PackSelectorProps) {
+  const {
+    packs,
+    isLoadingPacks,
+    packsError,
+    selectedPack,
+    selectPack,
+    confirmSelection,
+    isConfirming,
+    confirmError,
+    retryLoadPacks,
+  } = usePackSelector(visitorId);
+
+  const handleConfirm = async () => {
+    try {
+      await confirmSelection();
+      onComplete();
+    } catch {
+      // エラーはhook内で処理
+    }
+  };
+
+  if (isLoadingPacks) {
+    return <PackSelectorSkeleton />;
+  }
+
+  if (packsError) {
+    return (
+      <ErrorState
+        message="パック一覧の取得に失敗しました"
+        onRetry={retryLoadPacks}
+        onBack={onBack}
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col p-4 text-white" data-testid="pack-selector">
+      <header className="mb-6">
+        <button onClick={onBack} className="text-gray-400 hover:text-gray-200">
+          ← 戻る
+        </button>
+        <h1 className="mt-2 text-xl font-bold">スターターパックを選ぶ</h1>
+      </header>
+
+      <div className="flex flex-1 flex-col gap-4">
+        {packs.map((pack) => (
+          <PackCard
+            key={pack.type}
+            pack={pack}
+            isSelected={selectedPack?.type === pack.type}
+            onSelect={() => {
+              selectPack(pack);
+            }}
+            disabled={isConfirming}
+          />
+        ))}
+      </div>
+
+      {confirmError && (
+        <div className="mt-4 text-sm text-red-400">
+          選択に失敗しました。もう一度お試しください。
+        </div>
+      )}
+
+      <footer className="mt-6">
+        <button
+          onClick={() => {
+            void handleConfirm();
+          }}
+          disabled={!selectedPack || isConfirming}
+          className="w-full rounded-lg bg-blue-600 py-3 text-white disabled:opacity-50"
+        >
+          {isConfirming ? "設定中..." : "始める"}
+        </button>
+      </footer>
     </div>
   );
 }

--- a/apps/web/src/app/onboarding/_components/PackSelector/usePackSelector.ts
+++ b/apps/web/src/app/onboarding/_components/PackSelector/usePackSelector.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { api } from "@/shared/lib/api-client";
+
+export interface StarterPackInfo {
+  type: "horror" | "surreal" | "scientific" | "heartwarming" | "mystery";
+  displayName: string;
+  description: string;
+  primaryTags: string[];
+}
+
+interface UsePackSelectorResult {
+  packs: StarterPackInfo[];
+  isLoadingPacks: boolean;
+  packsError: Error | null;
+  selectedPack: StarterPackInfo | null;
+  selectPack: (pack: StarterPackInfo) => void;
+  confirmSelection: () => Promise<void>;
+  isConfirming: boolean;
+  confirmError: Error | null;
+  retryLoadPacks: () => void;
+}
+
+export function usePackSelector(visitorId: string): UsePackSelectorResult {
+  const [packs, setPacks] = useState<StarterPackInfo[]>([]);
+  const [isLoadingPacks, setIsLoadingPacks] = useState(true);
+  const [packsError, setPacksError] = useState<Error | null>(null);
+  const [selectedPack, setSelectedPack] = useState<StarterPackInfo | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [confirmError, setConfirmError] = useState<Error | null>(null);
+
+  const loadPacks = useCallback(async () => {
+    setIsLoadingPacks(true);
+    setPacksError(null);
+
+    try {
+      const res = await api.onboarding.packs.$get();
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
+      if (!res.ok) {
+        throw new Error("パック一覧の取得に失敗しました");
+      }
+
+      const data = (await res.json()) as { packs: StarterPackInfo[] };
+      setPacks(data.packs);
+    } catch (e) {
+      setPacksError(e instanceof Error ? e : new Error("パック一覧の取得に失敗しました"));
+    } finally {
+      setIsLoadingPacks(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPacks();
+  }, [loadPacks]);
+
+  const selectPack = useCallback((pack: StarterPackInfo) => {
+    setSelectedPack(pack);
+    setConfirmError(null);
+  }, []);
+
+  const confirmSelection = useCallback(async () => {
+    if (!selectedPack) {
+      return;
+    }
+
+    setIsConfirming(true);
+    setConfirmError(null);
+
+    try {
+      const res = await api.onboarding.select.$post({
+        json: {
+          visitorId,
+          packType: selectedPack.type,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
+      if (!res.ok) {
+        const errorData = (await res.json()) as { title?: string };
+        throw new Error(errorData.title ?? "選択に失敗しました");
+      }
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error("選択に失敗しました");
+      setConfirmError(error);
+      throw error;
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [selectedPack, visitorId]);
+
+  const retryLoadPacks = useCallback(() => {
+    void loadPacks();
+  }, [loadPacks]);
+
+  return {
+    packs,
+    isLoadingPacks,
+    packsError,
+    selectedPack,
+    selectPack,
+    confirmSelection,
+    isConfirming,
+    confirmError,
+    retryLoadPacks,
+  };
+}

--- a/apps/web/src/app/onboarding/_components/ScpNumberInput/ScpNumberTag.tsx
+++ b/apps/web/src/app/onboarding/_components/ScpNumberInput/ScpNumberTag.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface ScpNumberTagProps {
+  number: string;
+  onRemove: () => void;
+  isInvalid: boolean;
+  disabled: boolean;
+}
+
+export function ScpNumberTag({ number, onRemove, isInvalid, disabled }: ScpNumberTagProps) {
+  // "scp-173" → "SCP-173" に表示用変換
+  const displayNumber = number.toUpperCase();
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm ${
+        isInvalid ? "border border-red-300 bg-red-100 text-red-800" : "bg-gray-700 text-gray-200"
+      }`}
+    >
+      {displayNumber}
+      <button
+        onClick={onRemove}
+        disabled={disabled}
+        className="ml-1 text-gray-400 hover:text-gray-200 disabled:opacity-50"
+        aria-label={`${displayNumber}を削除`}
+      >
+        ×
+      </button>
+    </span>
+  );
+}

--- a/apps/web/src/app/onboarding/_components/ScpNumberInput/__tests__/useScpNumberInput.test.ts
+++ b/apps/web/src/app/onboarding/_components/ScpNumberInput/__tests__/useScpNumberInput.test.ts
@@ -1,0 +1,496 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useScpNumberInput } from "../useScpNumberInput";
+
+// api-clientのモック
+const mockPostCustomSelection = vi.fn();
+vi.mock("@/shared/lib/api-client", () => ({
+  api: {
+    onboarding: {
+      select: {
+        custom: {
+          $post: (...args: unknown[]): unknown => mockPostCustomSelection(...args),
+        },
+      },
+    },
+  },
+}));
+
+describe("useScpNumberInput", () => {
+  const visitorId = "test-visitor-id";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // デフォルトのモック実装を設定
+    mockPostCustomSelection.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, visitorId, articleCount: 3 }),
+    });
+  });
+
+  describe("初期状態", () => {
+    it("初期状態ではscpNumbersが空配列である", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      expect(result.current.scpNumbers).toEqual([]);
+      expect(result.current.inputValue).toBe("");
+      expect(result.current.inputError).toBeNull();
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.remainingCount).toBe(3);
+      expect(result.current.isConfirming).toBe(false);
+      expect(result.current.confirmError).toBeNull();
+      expect(result.current.invalidNumbers).toEqual([]);
+    });
+  });
+
+  describe("SCP番号追加（AC-2）", () => {
+    it("数字のみの形式で追加できる（例: 173）", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toContain("scp-173");
+      expect(result.current.inputValue).toBe("");
+    });
+
+    it("SCP-XXX形式で追加できる（例: SCP-682）", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("SCP-682");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toContain("scp-682");
+    });
+
+    it("小文字scp-xxx形式で追加できる（例: scp-999）", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("scp-999");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toContain("scp-999");
+    });
+
+    it("SCP_XXX形式で追加できる（例: SCP_2000）", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("SCP_2000");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toContain("scp-2000");
+    });
+
+    it("1桁の番号はゼロパディングされる（例: 1 → scp-001）", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("1");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toContain("scp-001");
+    });
+
+    it("追加後に入力フィールドがクリアされる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+
+      expect(result.current.inputValue).toBe("173");
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.inputValue).toBe("");
+    });
+  });
+
+  describe("入力形式バリデーション（AC-3）", () => {
+    it("無効な形式でエラーメッセージが表示される", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("invalid");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.inputError).not.toBeNull();
+      expect(result.current.scpNumbers).toEqual([]);
+    });
+
+    it("空文字では追加されない", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toEqual([]);
+    });
+
+    it("5桁以上の番号はエラーになる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("12345");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.inputError).not.toBeNull();
+      expect(result.current.scpNumbers).toEqual([]);
+    });
+  });
+
+  describe("重複チェック（AC-4）", () => {
+    it("既に追加済みの番号を入力すると重複エラーが表示される", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      act(() => {
+        result.current.setInputValue("SCP-173");
+      });
+
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.inputError).toBe("既に追加済みです");
+      expect(result.current.scpNumbers).toHaveLength(1);
+    });
+  });
+
+  describe("SCP番号削除（AC-5）", () => {
+    it("番号をリストから削除できる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toHaveLength(2);
+
+      act(() => {
+        result.current.removeNumber("scp-173");
+      });
+
+      expect(result.current.scpNumbers).toHaveLength(1);
+      expect(result.current.scpNumbers).not.toContain("scp-173");
+      expect(result.current.scpNumbers).toContain("scp-682");
+    });
+  });
+
+  describe("最低件数チェック（AC-6）", () => {
+    it("3件未満ではisValidがfalseになる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toHaveLength(2);
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("3件以上でisValidがtrueになる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("999");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.scpNumbers).toHaveLength(3);
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it("残り件数が正しく計算される", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      expect(result.current.remainingCount).toBe(3);
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.remainingCount).toBe(2);
+
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.remainingCount).toBe(1);
+
+      act(() => {
+        result.current.setInputValue("999");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.remainingCount).toBe(0);
+    });
+  });
+
+  describe("オンボーディング確定（AC-7）", () => {
+    it("confirmSelectionでAPIが呼び出される", async () => {
+      mockPostCustomSelection.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, visitorId, articleCount: 3 }),
+      });
+
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      // 3件追加
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("999");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      await act(async () => {
+        await result.current.confirmSelection();
+      });
+
+      expect(mockPostCustomSelection).toHaveBeenCalledWith({
+        json: {
+          visitorId,
+          articleIds: ["scp-173", "scp-682", "scp-999"],
+        },
+      });
+    });
+
+    it("確定中はisConfirmingがtrueになる", async () => {
+      let resolvePromise!: (value: unknown) => void;
+      mockPostCustomSelection.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvePromise = resolve;
+          })
+      );
+
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      // 3件追加（各操作を別々のactで実行）
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("999");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      // 3件追加されていることを確認
+      expect(result.current.scpNumbers).toHaveLength(3);
+      expect(result.current.isValid).toBe(true);
+
+      // confirmSelectionを開始（awaitしない）
+      let confirmPromise: Promise<void>;
+      act(() => {
+        confirmPromise = result.current.confirmSelection();
+      });
+
+      // isConfirmingがtrueになることを確認
+      expect(result.current.isConfirming).toBe(true);
+
+      // Promiseを解決
+      await act(async () => {
+        resolvePromise({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        });
+        await confirmPromise;
+      });
+
+      expect(result.current.isConfirming).toBe(false);
+    });
+  });
+
+  describe("存在しないSCP番号エラー（AC-8）", () => {
+    it("404エラー時にinvalidNumbersが設定される", async () => {
+      mockPostCustomSelection.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () =>
+          Promise.resolve({
+            type: "https://recommend-scp.dev/errors/not-found",
+            title: "Articles Not Found",
+            status: 404,
+            detail: "Some articles were not found",
+            invalidIds: ["scp-9999"],
+          }),
+      });
+
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      // 3件追加（1件は存在しない番号）
+      act(() => {
+        result.current.setInputValue("173");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("682");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+      act(() => {
+        result.current.setInputValue("9999");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      await act(async () => {
+        try {
+          await result.current.confirmSelection();
+        } catch {
+          // エラーをキャッチ
+        }
+      });
+
+      expect(result.current.confirmError).not.toBeNull();
+      expect(result.current.invalidNumbers).toContain("scp-9999");
+    });
+  });
+
+  describe("入力値の変更", () => {
+    it("setInputValueで入力値を変更できる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      act(() => {
+        result.current.setInputValue("173");
+      });
+
+      expect(result.current.inputValue).toBe("173");
+    });
+
+    it("入力値変更時にinputErrorがクリアされる", () => {
+      const { result } = renderHook(() => useScpNumberInput(visitorId));
+
+      // 無効な値を入力してエラーを発生させる
+      act(() => {
+        result.current.setInputValue("invalid");
+      });
+      act(() => {
+        result.current.addNumber();
+      });
+
+      expect(result.current.inputError).not.toBeNull();
+
+      // 新しい値を入力するとエラーがクリアされる
+      act(() => {
+        result.current.setInputValue("173");
+      });
+
+      expect(result.current.inputError).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/app/onboarding/_components/ScpNumberInput/index.tsx
+++ b/apps/web/src/app/onboarding/_components/ScpNumberInput/index.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useScpNumberInput } from "./useScpNumberInput";
+import { ScpNumberTag } from "./ScpNumberTag";
+
 export interface ScpNumberInputProps {
   visitorId: string;
   onComplete: () => void;
@@ -7,24 +10,123 @@ export interface ScpNumberInputProps {
 }
 
 /**
- * SCP番号入力コンポーネント（スタブ）
+ * SCP番号入力コンポーネント
  *
- * 006-01-03 で実装予定
+ * ユーザーが好きなSCP番号を入力して登録できる
  */
-export function ScpNumberInput({ onBack }: ScpNumberInputProps) {
+export function ScpNumberInput({ visitorId, onComplete, onBack }: ScpNumberInputProps) {
+  const {
+    inputValue,
+    setInputValue,
+    scpNumbers,
+    inputError,
+    addNumber,
+    removeNumber,
+    isValid,
+    remainingCount,
+    confirmSelection,
+    isConfirming,
+    confirmError,
+    invalidNumbers,
+  } = useScpNumberInput(visitorId);
+
+  const handleSubmit = async () => {
+    try {
+      await confirmSelection();
+      onComplete();
+    } catch {
+      // エラーはhook内で処理
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addNumber();
+    }
+  };
+
   return (
-    <div
-      data-testid="scp-number-input"
-      className="flex min-h-screen flex-col items-center justify-center p-4"
-    >
-      <h2 className="mb-8 text-2xl font-bold text-white">好きなSCPを教えてください</h2>
-      <p className="mb-8 text-gray-300">（実装予定）</p>
-      <button
-        onClick={onBack}
-        className="rounded-lg border border-gray-600 bg-gray-800 px-4 py-2 text-white transition-colors hover:bg-gray-700"
-      >
-        戻る
-      </button>
+    <div className="flex min-h-screen flex-col p-4 text-white" data-testid="scp-number-input">
+      <header className="mb-6">
+        <button onClick={onBack} className="text-gray-400 hover:text-gray-200">
+          ← 戻る
+        </button>
+        <h1 className="mt-2 text-xl font-bold">好きなSCPを教えてください</h1>
+        <p className="mt-1 text-sm text-gray-400">最低3つのSCP番号を入力してください</p>
+      </header>
+
+      {/* 入力フォーム */}
+      <div className="mb-4 flex gap-2">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="例: 173, SCP-682"
+          className="flex-1 rounded-lg border border-gray-600 bg-gray-800 p-3 text-white placeholder-gray-500"
+          disabled={isConfirming}
+        />
+        <button
+          onClick={addNumber}
+          disabled={isConfirming || !inputValue.trim()}
+          className="rounded-lg bg-gray-700 px-4 py-2 text-white disabled:opacity-50"
+        >
+          追加
+        </button>
+      </div>
+
+      {inputError && <p className="mb-4 text-sm text-red-400">{inputError}</p>}
+
+      {/* 入力済みリスト */}
+      <div className="flex-1">
+        <div className="flex flex-wrap gap-2">
+          {scpNumbers.map((num) => (
+            <ScpNumberTag
+              key={num}
+              number={num}
+              onRemove={() => {
+                removeNumber(num);
+              }}
+              isInvalid={invalidNumbers.includes(num)}
+              disabled={isConfirming}
+            />
+          ))}
+        </div>
+
+        {scpNumbers.length === 0 && (
+          <p className="mt-8 text-center text-gray-500">まだSCP番号が入力されていません</p>
+        )}
+      </div>
+
+      {/* 残り件数 */}
+      {!isValid && (
+        <p className="mt-4 text-center text-sm text-gray-400">あと{remainingCount}件必要です</p>
+      )}
+
+      {/* 確定エラー */}
+      {confirmError && (
+        <div className="mt-4 text-sm text-red-400">
+          {invalidNumbers.length > 0
+            ? `存在しないSCP番号があります: ${invalidNumbers.join(", ")}`
+            : "エラーが発生しました。もう一度お試しください。"}
+        </div>
+      )}
+
+      {/* 確定ボタン */}
+      <footer className="mt-6">
+        <button
+          onClick={() => {
+            void handleSubmit();
+          }}
+          disabled={!isValid || isConfirming}
+          className="w-full rounded-lg bg-blue-600 py-3 text-white disabled:opacity-50"
+        >
+          {isConfirming ? "設定中..." : `始める（${String(scpNumbers.length)}件選択中）`}
+        </button>
+      </footer>
     </div>
   );
 }

--- a/apps/web/src/app/onboarding/_components/ScpNumberInput/useScpNumberInput.ts
+++ b/apps/web/src/app/onboarding/_components/ScpNumberInput/useScpNumberInput.ts
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { api } from "@/shared/lib/api-client";
+
+const MIN_REQUIRED_COUNT = 3;
+
+// 許可される入力形式
+const SCP_NUMBER_PATTERNS = [
+  /^(\d{1,4})$/, // 例: 173, 2000
+  /^SCP-(\d{1,4})$/i, // 例: SCP-173, scp-173
+  /^SCP_(\d{1,4})$/i, // 例: SCP_173
+];
+
+// 正規化関数
+function normalizeScpNumber(input: string): string | null {
+  const trimmed = input.trim();
+  for (const pattern of SCP_NUMBER_PATTERNS) {
+    const match = trimmed.match(pattern);
+    if (match) {
+      const num = match[1];
+      // 3桁以上にパディング
+      const paddedNum = num.length < 3 ? num.padStart(3, "0") : num;
+      return `scp-${paddedNum}`;
+    }
+  }
+  return null;
+}
+
+interface UseScpNumberInputResult {
+  /** 入力中の値 */
+  inputValue: string;
+  setInputValue: (value: string) => void;
+  /** 追加済みSCP番号リスト（正規化済み） */
+  scpNumbers: string[];
+  /** 入力バリデーションエラー */
+  inputError: string | null;
+  /** 番号を追加 */
+  addNumber: () => void;
+  /** 番号を削除 */
+  removeNumber: (number: string) => void;
+  /** 最低件数を満たしているか */
+  isValid: boolean;
+  /** 残り必要件数 */
+  remainingCount: number;
+  /** オンボーディング確定 */
+  confirmSelection: () => Promise<void>;
+  /** 確定処理中 */
+  isConfirming: boolean;
+  /** 確定エラー */
+  confirmError: Error | null;
+  /** 存在しないSCP番号（APIエラー時） */
+  invalidNumbers: string[];
+}
+
+export function useScpNumberInput(visitorId: string): UseScpNumberInputResult {
+  const [inputValue, setInputValueState] = useState("");
+  const [scpNumbers, setScpNumbers] = useState<string[]>([]);
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [confirmError, setConfirmError] = useState<Error | null>(null);
+  const [invalidNumbers, setInvalidNumbers] = useState<string[]>([]);
+
+  const setInputValue = useCallback((value: string) => {
+    setInputValueState(value);
+    setInputError(null); // 入力値変更時にエラーをクリア
+  }, []);
+
+  const isValid = useMemo(() => scpNumbers.length >= MIN_REQUIRED_COUNT, [scpNumbers.length]);
+
+  const remainingCount = useMemo(
+    () => Math.max(0, MIN_REQUIRED_COUNT - scpNumbers.length),
+    [scpNumbers.length]
+  );
+
+  const addNumber = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const normalized = normalizeScpNumber(trimmed);
+    if (!normalized) {
+      setInputError("無効な形式です。例: 173, SCP-173");
+      return;
+    }
+
+    // 重複チェック
+    if (scpNumbers.includes(normalized)) {
+      setInputError("既に追加済みです");
+      return;
+    }
+
+    setScpNumbers((prev) => [...prev, normalized]);
+    setInputValueState("");
+    setInputError(null);
+  }, [inputValue, scpNumbers]);
+
+  const removeNumber = useCallback((number: string) => {
+    setScpNumbers((prev) => prev.filter((n) => n !== number));
+    // 削除した番号がinvalidNumbersに含まれていたら除去
+    setInvalidNumbers((prev) => prev.filter((n) => n !== number));
+  }, []);
+
+  const confirmSelection = useCallback(async () => {
+    if (!isValid) {
+      return;
+    }
+
+    setIsConfirming(true);
+    setConfirmError(null);
+    setInvalidNumbers([]);
+
+    try {
+      const res = await api.onboarding.select.custom.$post({
+        json: {
+          visitorId,
+          articleIds: scpNumbers,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
+      if (!res.ok) {
+        const errorData = (await res.json()) as {
+          title?: string;
+          invalidIds?: string[];
+        };
+        // Hono RPCの型推論では res.status が 200 型に推論されるが、実行時には 404 になる可能性がある
+        if ((res.status as number) === 404 && errorData.invalidIds) {
+          setInvalidNumbers(errorData.invalidIds);
+        }
+        throw new Error(errorData.title ?? "エラーが発生しました");
+      }
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error("Unknown error");
+      setConfirmError(error);
+      throw error;
+    } finally {
+      setIsConfirming(false);
+    }
+  }, [isValid, visitorId, scpNumbers]);
+
+  return {
+    inputValue,
+    setInputValue,
+    scpNumbers,
+    inputError,
+    addNumber,
+    removeNumber,
+    isValid,
+    remainingCount,
+    confirmSelection,
+    isConfirming,
+    confirmError,
+    invalidNumbers,
+  };
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       exclude: ["node_modules", ".next", "src/test", "**/*.d.ts", "**/*.config.*"],
     },
+    env: {
+      NEXT_PUBLIC_API_URL: "http://localhost:3001",
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
006-01-01: オンボーディング画面実装
- page.tsx: メインエントリーポイント
- OnboardingSelect: 選択肢画面コンポーネント
- useOnboarding: フロー管理フック

006-01-02: パック選択コンポーネント
- PackSelector: パック一覧表示・選択
- PackCard: パックカードコンポーネント
- usePackSelector: パック選択ロジック

006-01-03: SCP番号入力コンポーネント
- ScpNumberInput: 番号入力フォーム
- ScpNumberTag: 入力済みタグ表示
- useScpNumberInput: 入力バリデーション・API連携

https://claude.ai/code/session_01RejQB45mgD9HU35KcGrQgp