### PR TITLE
Refactor Claude Code hooks to use external script

### DIFF
--- a/.claude/hooks/user-prompt-reminder.sh
+++ b/.claude/hooks/user-prompt-reminder.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# UserPromptSubmit hook - プロンプトに応じたリマインダーを表示
+# Claude Codeが自動発動すべきSkillを忘れないためのフック
+
+# Read hook input from stdin
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+
+# Pattern 1: 実装開始キーワード
+if echo "$PROMPT" | grep -qE '実装して|開発して|作成して|Subtask.*開始|[0-9]{3}-[0-9]{2}-[0-9]{2}'; then
+  echo '⚠️ リマインダー: spec-workflow Skillを発動してください。直接実装を始めないでください。'
+  exit 0
+fi
+
+# Pattern 2: PR作成キーワード
+if echo "$PROMPT" | grep -qiE 'PR.*作成|プルリク|pull.?request'; then
+  echo '⚠️ リマインダー: PR作成前に code-reviewer と quality-gate サブエージェントを実行してください。'
+  exit 0
+fi
+
+# Pattern 3: 仕様策定キーワード
+if echo "$PROMPT" | grep -qE '仕様.*策定|spec.*作成|仕様書'; then
+  echo '⚠️ リマインダー: /spec Skillを発動してください。'
+  exit 0
+fi
+
+# No matching pattern - no output
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,18 +1,14 @@
 {
-  "$schema": "https://claude.ai/code/settings-schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
     "UserPromptSubmit": [
       {
-        "matcher": "実装して|開発して|作成して|Subtask.*開始|[0-9]{3}-[0-9]{2}-[0-9]{2}",
-        "command": "echo '⚠️ リマインダー: spec-workflow Skillを発動してください。直接実装を始めないでください。'"
-      },
-      {
-        "matcher": "PR.*作成|プルリク|pull request",
-        "command": "echo '⚠️ リマインダー: PR作成前に code-reviewer と quality-gate サブエージェントを実行してください。'"
-      },
-      {
-        "matcher": "仕様.*策定|spec.*作成|仕様書",
-        "command": "echo '⚠️ リマインダー: /spec Skillを発動してください。'"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/user-prompt-reminder.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
Refactored the UserPromptSubmit hook configuration to use an external bash script instead of inline commands, improving maintainability and reusability of hook logic.

## Key Changes
- Created `.claude/hooks/user-prompt-reminder.sh` - A new bash script that centralizes all prompt pattern matching and reminder logic
  - Implements three reminder patterns: implementation keywords, PR creation keywords, and spec definition keywords
  - Reads hook input from stdin and parses JSON prompt data
  - Uses grep regex patterns for flexible keyword matching
  
- Updated `.claude/settings.json` - Simplified hook configuration
  - Replaced three separate inline command hooks with a single reference to the external script
  - Fixed schema URL from `claude.ai` to `json.schemastore.org` for better compatibility
  - Restructured hook configuration to use new `hooks` array format with `type: "command"`

## Benefits
- **Maintainability**: Hook logic is now in a dedicated script file, easier to update and test
- **Reusability**: The script can be referenced from multiple hook configurations if needed
- **Clarity**: Separates configuration from implementation
- **Consistency**: Aligns with standard practices of externalizing complex logic from config files

https://claude.ai/code/session_01HBcg6q8PgC9x8RVW7ZCY39