### PR TITLE
fix(spec): EPIC/Story/Subtaskのステータス整合性を修正

### DIFF
--- a/specs/005-backend-api/story-list.md
+++ b/specs/005-backend-api/story-list.md
@@ -10,7 +10,7 @@
 | [005-06](./005-06-feedback-api/005-06.md)   | feedback API         | Like/Dislike記録エンドポイント                       | completed  |
 | [005-07](./005-07-onboarding-api/005-07.md) | onboarding API       | スターターパック一覧・選択エンドポイント             | completed  |
 | [005-08](./005-08-api-types/005-08.md)      | 型共有パッケージ     | packages/api-typesでRPC型をexport                    | completed  |
-| [005-09](./005-09-docs-update/005-09.md)    | ドキュメント更新     | アーキテクチャ変更の反映                             | planned    |
+| [005-09](./005-09-docs-update/005-09.md)    | ドキュメント更新     | アーキテクチャ変更の反映                             | completed  |
 | [005-10](./005-10-favorites-api/005-10.md)  | favorites API        | お気に入り一覧取得・削除エンドポイント               | completed  |
 
 ## 依存関係グラフ

--- a/specs/006-frontend/story-list.md
+++ b/specs/006-frontend/story-list.md
@@ -5,11 +5,11 @@
 | [006-00](./006-00-mockups/006-00.md)          | UIモック作成           | 静的HTMLモックでUI方向性を確定                | completed  |
 | [006-00](./006-00-web-foundation/006-00.md)   | フロントエンド環境構築 | Next.js初期化、Tailwind、APIクライアント      | completed  |
 | [006-00](./006-00-common-ui/006-00.md)        | 共通UIコンポーネント   | ドロワー・メニューボタン・ピルナビ・バッジ等  | completed  |
-| [006-01](./006-01-onboarding/006-01.md)       | オンボーディング       | パック選択・SCP番号指定による初期設定         | pending    |
+| [006-01](./006-01-onboarding/006-01.md)       | オンボーディング       | パック選択・SCP番号指定による初期設定         | completed  |
 | [006-02](./006-02-article-reader/006-02.md)   | 記事閲覧               | 全画面WebView・無限スクロール・フィードバック | completed  |
 | [006-03](./006-03-favorites/006-03.md)        | お気に入り管理         | お気に入り一覧・再読・解除                    | completed  |
-| [006-04](./006-04-history/006-04.md)          | 閲覧履歴               | 履歴記録・一覧表示・遷移                      | pending    |
-| [006-ex01](./006-ex01-design-fix/006-ex01.md) | デザイン整合性修正     | SVGアイコン化・モックアップ準拠修正           | pending    |
+| [006-04](./006-04-history/006-04.md)          | 閲覧履歴               | 履歴記録・一覧表示・遷移                      | completed  |
+| [006-ex01](./006-ex01-design-fix/006-ex01.md) | デザイン整合性修正     | SVGアイコン化・モックアップ準拠修正           | completed  |
 
 ## 依存関係グラフ
 

--- a/specs/epic-list.md
+++ b/specs/epic-list.md
@@ -8,7 +8,7 @@
 | [002](./002-quality/002-quality.md)                       | 開発環境品質基盤             | ESLint/Prettier/lefthook/CI環境を整備                     | completed  |
 | [003](./003-data-pipeline/003-data-pipeline.md)           | データパイプライン本番化     | 全記事クロール・差分更新・タグ辞書DB管理                  | completed  |
 | [004](./004-recommend/004-recommend.md)                   | 推薦ロジック実装             | ハイブリッド推薦・80/20セレンディピティ・オンボーディング | completed  |
-| [005](./005-backend-api/005-backend-api.md)               | バックエンドAPI              | 検索・推薦・フィードバック収集のRESTエンドポイント        | planned    |
+| [005](./005-backend-api/005-backend-api.md)               | バックエンドAPI              | 検索・推薦・フィードバック収集のRESTエンドポイント        | completed  |
 | [006](./006-frontend/006-frontend.md)                     | フロントエンドUI             | オンボーディング・記事閲覧・お気に入り管理                | planned    |
 | [007](./007-infra/007-infra.md)                           | インフラ・デプロイ           | 本番環境構築・CI/CD・シークレット管理                     | completed  |
 | [008](./008-observability/008-observability.md)           | 運用・監視                   | ログ収集・エラー監視・パフォーマンスダッシュボード        | planned    |


### PR DESCRIPTION
- EPIC-005: planned → completed（全Storyがcompleted）
- Story 005-09: planned → completed（全Subtaskがcompleted）
- Story 006-01: pending → completed（全Subtaskがcompleted）
- Story 006-04: pending → completed（全Subtaskがcompleted）
- Story 006-ex01: pending → completed（全Subtaskがcompleted）

https://claude.ai/code/session_01WqLLVsVoLGKemYGyjHvSuq