### PR TITLE
fix(web): 翻訳なし記事のカード重複表示を修正

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
@@ -97,9 +97,13 @@ export function ArticleWebView({
     onSkip?.();
   }, [onSkip]);
 
-  // サジェスト画面表示
+  // サジェスト画面表示（通常のArticleWebViewと同じ高さを維持し、次記事が見えないようにする）
   if (showNotFound) {
-    return <TranslationNotFound onSuggest={handleSuggest} />;
+    return (
+      <div className={cn("relative w-full h-[calc(100vh-100px)]", className)}>
+        <TranslationNotFound onSuggest={handleSuggest} />
+      </div>
+    );
   }
 
   return (

--- a/apps/web/src/app/(main)/recommend/_hooks/useInfiniteArticles.ts
+++ b/apps/web/src/app/(main)/recommend/_hooks/useInfiniteArticles.ts
@@ -159,7 +159,11 @@ export function useInfiniteArticles(
       const hasMoreData: boolean = data.hasMore ?? false;
 
       if (isMountedRef.current) {
-        setArticles((prev) => [...prev, ...newArticles]);
+        setArticles((prev) => {
+          const existingIds = new Set(prev.map((a) => a.id));
+          const uniqueNewArticles = newArticles.filter((a) => !existingIds.has(a.id));
+          return [...prev, ...uniqueNewArticles];
+        });
         setHasMore(hasMoreData);
       }
     } catch {


### PR DESCRIPTION
TranslationNotFound表示時にArticleWebViewと同じ高さ(h-[calc(100vh-100px)])の
コンテナで囲むことで、次の記事のTranslationNotFoundカードがビューポート内に
表示されるのを防止。

また、loadMoreでの記事追加時にIDベースの重複排除を追加し、
同一記事が複数回追加されることを防止。

https://claude.ai/code/session_01VKR5At4WGmfzJPqrKXGadh