### PR TITLE
AC-9: Replace dislike with skip feedback type and add metadata

### DIFF
--- a/apps/api-server/src/domains/feedback/__dev__/routes.test.ts
+++ b/apps/api-server/src/domains/feedback/__dev__/routes.test.ts
@@ -373,6 +373,104 @@ describe("POST /feedback - 異常系（バリデーションエラー）", () =>
   });
 });
 
+describe("POST /feedback - AC-9: skip型対応", () => {
+  let app: Hono;
+  let mockService: MockService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockService = {
+      recordFeedback: vi.fn(),
+    };
+    app = createTestApp(mockService);
+  });
+
+  it("type=skipのリクエストで200を返す", async () => {
+    // Arrange
+    mockService.recordFeedback.mockResolvedValue(undefined);
+
+    // Act
+    const res = await app.request("/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
+
+  it("skip型フィードバックがserviceに渡される", async () => {
+    // Arrange
+    mockService.recordFeedback.mockResolvedValue(undefined);
+
+    // Act
+    await app.request("/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        },
+      }),
+    });
+
+    // Assert: metadataはスキーマで受け付けるがserviceにはtype情報のみ渡す
+    expect(mockService.recordFeedback).toHaveBeenCalledWith(
+      VALID_VISITOR_ID,
+      VALID_ARTICLE_ID,
+      "skip"
+    );
+  });
+
+  it("metadataなしでも正常に処理される", async () => {
+    // Arrange
+    mockService.recordFeedback.mockResolvedValue(undefined);
+
+    // Act
+    const res = await app.request("/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
+
+  it("type=dislikeが引き続き受け付けられる（後方互換性）", async () => {
+    // Arrange
+    mockService.recordFeedback.mockResolvedValue(undefined);
+
+    // Act
+    const res = await app.request("/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "dislike",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("POST /feedback - エッジケース", () => {
   let app: Hono;
   let mockService: MockService;

--- a/apps/api-server/src/domains/feedback/__dev__/schema.test.ts
+++ b/apps/api-server/src/domains/feedback/__dev__/schema.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @file Feedback APIスキーマテスト
+ * @description AC-9: API後方互換性のバリデーションテスト
+ * @see specs/006-frontend/006-05-transition-ux/006-05-06.md
+ */
+
+import { describe, it, expect } from "vitest";
+import { recordFeedbackSchema } from "../schema";
+
+const VALID_VISITOR_ID = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_ARTICLE_ID = "scp-173";
+
+describe("recordFeedbackSchema", () => {
+  describe("AC-9: API後方互換性", () => {
+    it("type=skipのリクエストが検証に通る", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("type=likeのリクエストが検証に通る（後方互換性）", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "like",
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("type=dislikeのリクエストが検証に通る（後方互換性）", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "dislike",
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("metadataフィールドがオプショナルで受け付けられる", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("metadataなしでも検証に通る", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    it("metadataのscrollDepthが0-100の範囲で受け付けられる", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 0,
+          dwellTime: 0,
+          interestLevel: "skip",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("無効なtypeで検証に失敗する", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "invalid",
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("metadata.scrollDepthが負の値で検証に失敗する", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: -10,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("metadata.scrollDepthが100超で検証に失敗する", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 150,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("metadata.dwellTimeが負の値で検証に失敗する", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 30,
+          dwellTime: -5,
+          interestLevel: "neutral",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+
+    it("metadata.interestLevelが無効な値で検証に失敗する", () => {
+      const input = {
+        visitorId: VALID_VISITOR_ID,
+        articleId: VALID_ARTICLE_ID,
+        type: "skip",
+        metadata: {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "invalid",
+        },
+      };
+
+      const result = recordFeedbackSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api-server/src/domains/feedback/repository.ts
+++ b/apps/api-server/src/domains/feedback/repository.ts
@@ -12,7 +12,7 @@ interface FeedbackRow {
   id: string;
   visitor_id: string;
   article_id: string;
-  type: "like" | "dislike";
+  type: "like" | "dislike" | "skip";
   created_at: string;
 }
 

--- a/apps/api-server/src/domains/feedback/routes.ts
+++ b/apps/api-server/src/domains/feedback/routes.ts
@@ -46,11 +46,12 @@ export const createFeedbackRoutes = (
   /**
    * POST /feedback
    *
-   * フィードバック（Like/Dislike）を記録
+   * フィードバック（Like/Dislike/Skip）を記録
    *
    * @param visitorId - 訪問者ID（UUID）
    * @param articleId - 記事ID
-   * @param type - フィードバック種別（like/dislike）
+   * @param type - フィードバック種別（like/dislike/skip）
+   * @param metadata - スキップメタデータ（オプション）
    *
    * Response:
    * - 200 OK: フィードバック記録成功

--- a/apps/api-server/src/domains/feedback/schema.ts
+++ b/apps/api-server/src/domains/feedback/schema.ts
@@ -2,17 +2,32 @@
  * @file Feedback APIスキーマ
  * @description POST /feedback のバリデーションスキーマ
  * @see specs/005-backend-api/005-06-feedback-api/005-06-02.md
+ * @see specs/006-frontend/006-05-transition-ux/006-05-06.md
  */
 
 import { z } from "zod";
 
 /**
+ * スキップメタデータのバリデーションスキーマ
+ */
+const feedbackMetadataSchema = z.object({
+  scrollDepth: z.number().min(0).max(100),
+  dwellTime: z.number().min(0),
+  interestLevel: z.enum(["skip", "neutral", "like"]),
+});
+
+/**
  * POST /feedback リクエストボディのバリデーションスキーマ
+ *
+ * AC-9: "skip"型を追加、メタデータをオプショナルで受付
+ * 後方互換性: "dislike"も引き続き受け付ける
  */
 export const recordFeedbackSchema = z.object({
   visitorId: z.string().uuid(),
   articleId: z.string().min(1),
-  type: z.enum(["like", "dislike"]),
+  type: z.enum(["like", "dislike", "skip"]),
+  metadata: feedbackMetadataSchema.optional(),
 });
 
 export type RecordFeedbackInput = z.infer<typeof recordFeedbackSchema>;
+export type FeedbackMetadata = z.infer<typeof feedbackMetadataSchema>;

--- a/apps/api-server/src/domains/feedback/service.ts
+++ b/apps/api-server/src/domains/feedback/service.ts
@@ -29,13 +29,13 @@ export class FeedbackService {
    *
    * @param visitorId - 訪問者ID
    * @param articleId - 記事ID
-   * @param type - フィードバック種別（like/dislike）
+   * @param type - フィードバック種別（like/dislike/skip）
    * @throws NotFoundError visitorIdが未登録の場合
    */
   recordFeedback = async (
     visitorId: string,
     articleId: string,
-    type: "like" | "dislike"
+    type: "like" | "dislike" | "skip"
   ): Promise<void> => {
     // visitorIdの存在確認
     const visitor = await this.visitorsRepo.findByVisitorId(visitorId);

--- a/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
@@ -25,7 +25,11 @@ const mockUseInfiniteArticlesResult = {
 
 const mockUseFeedbackResult = {
   recordLike: vi.fn(),
-  recordDislike: vi.fn(),
+  recordSkip: vi.fn(),
+  recordFavorite: vi.fn(),
+  hasRecorded: vi.fn().mockReturnValue(false),
+  getFeedbackType: vi.fn().mockReturnValue(null),
+  pendingCount: 0,
 };
 
 const mockUseArticleFavoriteResult = {
@@ -41,6 +45,11 @@ vi.mock("../_hooks/useInfiniteArticles", () => ({
 // useFeedbackをモック
 vi.mock("../_hooks/useFeedback", () => ({
   useFeedback: () => mockUseFeedbackResult,
+  calculateInterestLevel: (scrollDepth: number, dwellTime: number) => {
+    if (scrollDepth < 10 && dwellTime < 5) return "skip";
+    if (scrollDepth > 50 && dwellTime > 30) return "like";
+    return "neutral";
+  },
 }));
 
 // useArticleFavoriteをモック
@@ -294,7 +303,7 @@ describe("RecommendPage", () => {
       expect(mockUseArticleFavoriteResult.toggleFavorite).toHaveBeenCalled();
     });
 
-    it("次へボタンをクリックするとgoToNextとrecordDislikeが呼ばれる", async () => {
+    it("次へボタンをクリックするとgoToNextとrecordSkipが呼ばれる", async () => {
       const user = userEvent.setup();
       mockUseInfiniteArticlesResult.isLoading = false;
       mockUseInfiniteArticlesResult.articles = mockArticles;
@@ -305,7 +314,15 @@ describe("RecommendPage", () => {
       const nextButton = await screen.findByLabelText("次の記事へ");
       await user.click(nextButton);
 
-      expect(mockUseFeedbackResult.recordDislike).toHaveBeenCalledWith(mockArticle.id);
+      expect(mockUseFeedbackResult.recordSkip).toHaveBeenCalledWith(
+        mockArticle.id,
+
+        expect.objectContaining({
+          scrollDepth: expect.any(Number) as number,
+          dwellTime: expect.any(Number) as number,
+          interestLevel: expect.stringMatching(/^(skip|neutral|like)$/) as string,
+        })
+      );
       expect(mockUseInfiniteArticlesResult.goToNext).toHaveBeenCalled();
     });
   });
@@ -439,8 +456,8 @@ describe("RecommendPage", () => {
       const nextButton = screen.getByLabelText("次の記事へ");
       fireEvent.click(nextButton);
 
-      // 遷移中はrecordDislikeが呼ばれない（ブロック）
-      expect(mockUseFeedbackResult.recordDislike).not.toHaveBeenCalled();
+      // 遷移中はrecordSkipが呼ばれない（ブロック）
+      expect(mockUseFeedbackResult.recordSkip).not.toHaveBeenCalled();
 
       // 遷移完了
       act(() => {
@@ -472,7 +489,15 @@ describe("RecommendPage", () => {
 
       // goToNextが再度呼ばれる
       expect(mockUseInfiniteArticlesResult.goToNext).toHaveBeenCalledTimes(2);
-      expect(mockUseFeedbackResult.recordDislike).toHaveBeenCalledWith(mockArticles[0].id);
+      expect(mockUseFeedbackResult.recordSkip).toHaveBeenCalledWith(
+        mockArticles[0].id,
+
+        expect.objectContaining({
+          scrollDepth: expect.any(Number) as number,
+          dwellTime: expect.any(Number) as number,
+          interestLevel: expect.stringMatching(/^(skip|neutral|like)$/) as string,
+        })
+      );
     });
 
     it("スクロール遷移を連続で開始しても1回のみ実行される", () => {
@@ -552,7 +577,15 @@ describe("RecommendPage", () => {
 
       // 即座にgoToNextが呼ばれる（タイマー待ちなし）
       expect(mockUseInfiniteArticlesResult.goToNext).toHaveBeenCalledTimes(1);
-      expect(mockUseFeedbackResult.recordDislike).toHaveBeenCalledWith(mockArticles[0].id);
+      expect(mockUseFeedbackResult.recordSkip).toHaveBeenCalledWith(
+        mockArticles[0].id,
+
+        expect.objectContaining({
+          scrollDepth: expect.any(Number) as number,
+          dwellTime: expect.any(Number) as number,
+          interestLevel: expect.stringMatching(/^(skip|neutral|like)$/) as string,
+        })
+      );
     });
   });
 });

--- a/apps/web/src/app/(main)/recommend/_hooks/__tests__/useFeedback.test.ts
+++ b/apps/web/src/app/(main)/recommend/_hooks/__tests__/useFeedback.test.ts
@@ -1,6 +1,6 @@
 /**
  * @file useFeedback フックのテスト
- * @see specs/006-frontend/006-02-article-reader/006-02-05.md
+ * @see specs/006-frontend/006-05-transition-ux/006-05-06.md
  */
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -19,7 +19,7 @@ vi.mock("@/shared/hooks/useVisitorId", () => ({
 }));
 
 // モックの後でインポート
-import { useFeedback } from "../useFeedback";
+import { useFeedback, calculateInterestLevel } from "../useFeedback";
 import { api } from "@/shared/lib/api-client";
 import { useVisitorId } from "@/shared/hooks/useVisitorId";
 
@@ -84,18 +84,199 @@ describe("useFeedback", () => {
     vi.useRealTimers();
   });
 
-  describe("AC-1: 読了判定（暗黙的Like）", () => {
-    it("recordLike()でtype=likeのフィードバックが送信される", async () => {
-      // Arrange
+  describe("AC-1: Dislike記録の廃止", () => {
+    it("recordDislikeメソッドが存在しない", () => {
+      const { result } = renderHook(() => useFeedback());
+      expect(result.current).not.toHaveProperty("recordDislike");
+    });
+
+    it("recordSkipメソッドが存在する", () => {
+      const { result } = renderHook(() => useFeedback());
+      expect(result.current).toHaveProperty("recordSkip");
+      expect(typeof result.current.recordSkip).toBe("function");
+    });
+  });
+
+  describe("AC-2: 暗黙的フィードバックの記録", () => {
+    it("recordSkip()でtype=skipのフィードバックが送信される", async () => {
+      const { result } = renderHook(() => useFeedback());
+      const metadata = {
+        scrollDepth: 30,
+        dwellTime: 15,
+        interestLevel: "neutral" as const,
+      };
+
+      await act(async () => {
+        await result.current.recordSkip("scp-173", metadata);
+      });
+
+      expect(mockApi.feedback.$post).toHaveBeenCalledWith({
+        json: {
+          visitorId: "test-visitor-id",
+          articleId: "scp-173",
+          type: "skip",
+          metadata: {
+            scrollDepth: 30,
+            dwellTime: 15,
+            interestLevel: "neutral",
+          },
+        },
+      });
+    });
+
+    it("メタデータが正しくAPI呼び出しに含まれる", async () => {
+      const { result } = renderHook(() => useFeedback());
+      const metadata = {
+        scrollDepth: 70,
+        dwellTime: 45,
+        interestLevel: "like" as const,
+      };
+
+      await act(async () => {
+        await result.current.recordSkip("scp-096", metadata);
+      });
+
+      expect(mockApi.feedback.$post).toHaveBeenCalledWith(
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          json: expect.objectContaining({
+            metadata: {
+              scrollDepth: 70,
+              dwellTime: 45,
+              interestLevel: "like",
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  describe("AC-3: 低興味判定（skip）", () => {
+    it("scrollDepth=5%, dwellTime=3sでinterestLevel=skipが算出される", () => {
+      expect(calculateInterestLevel(5, 3)).toBe("skip");
+    });
+
+    it("scrollDepth=9%, dwellTime=4sでinterestLevel=skipが算出される（境界値内）", () => {
+      expect(calculateInterestLevel(9, 4)).toBe("skip");
+    });
+
+    it("scrollDepth=0%, dwellTime=0sでinterestLevel=skipが算出される", () => {
+      expect(calculateInterestLevel(0, 0)).toBe("skip");
+    });
+  });
+
+  describe("AC-4: 中興味判定（neutral）", () => {
+    it("scrollDepth=30%, dwellTime=15sでinterestLevel=neutralが算出される", () => {
+      expect(calculateInterestLevel(30, 15)).toBe("neutral");
+    });
+
+    it("境界値: scrollDepth=10%, dwellTime=5sでinterestLevel=neutralが算出される", () => {
+      expect(calculateInterestLevel(10, 5)).toBe("neutral");
+    });
+
+    it("境界値: scrollDepth=50%, dwellTime=30sでinterestLevel=neutralが算出される", () => {
+      expect(calculateInterestLevel(50, 30)).toBe("neutral");
+    });
+
+    it("scrollDepth=20%, dwellTime=3sでinterestLevel=neutralが算出される（スクロール条件のみ満たす）", () => {
+      expect(calculateInterestLevel(20, 3)).toBe("neutral");
+    });
+
+    it("scrollDepth=5%, dwellTime=10sでinterestLevel=neutralが算出される（時間条件のみ満たす）", () => {
+      expect(calculateInterestLevel(5, 10)).toBe("neutral");
+    });
+  });
+
+  describe("AC-5: 高興味判定（like）", () => {
+    it("scrollDepth=70%, dwellTime=45sでinterestLevel=likeが算出される", () => {
+      expect(calculateInterestLevel(70, 45)).toBe("like");
+    });
+
+    it("境界値: scrollDepth=51%, dwellTime=31sでinterestLevel=likeが算出される", () => {
+      expect(calculateInterestLevel(51, 31)).toBe("like");
+    });
+
+    it("scrollDepth=100%, dwellTime=60sでinterestLevel=likeが算出される", () => {
+      expect(calculateInterestLevel(100, 60)).toBe("like");
+    });
+  });
+
+  describe("AC-8: 既存Like/Favoriteとの優先度", () => {
+    it("既にLike記録済みの記事でrecordSkip()がスキップされる", async () => {
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Act
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert
+      mockApi.feedback.$post.mockClear();
+
+      await act(async () => {
+        await result.current.recordSkip(articleId, {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
+      });
+
+      expect(mockApi.feedback.$post).not.toHaveBeenCalled();
+      expect(result.current.getFeedbackType(articleId)).toBe("like");
+    });
+
+    it("既にFavorite記録済みの記事でrecordSkip()がスキップされる", async () => {
+      const { result } = renderHook(() => useFeedback());
+      const articleId = "scp-173";
+
+      await act(async () => {
+        await result.current.recordFavorite(articleId);
+      });
+
+      mockApi.feedback.$post.mockClear();
+
+      await act(async () => {
+        await result.current.recordSkip(articleId, {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
+      });
+
+      expect(mockApi.feedback.$post).not.toHaveBeenCalled();
+      expect(result.current.getFeedbackType(articleId)).toBe("favorite");
+    });
+
+    it("Skip記録後にLikeで上書きされる", async () => {
+      const { result } = renderHook(() => useFeedback());
+      const articleId = "scp-173";
+
+      await act(async () => {
+        await result.current.recordSkip(articleId, {
+          scrollDepth: 5,
+          dwellTime: 3,
+          interestLevel: "skip",
+        });
+      });
+
+      expect(result.current.getFeedbackType(articleId)).toBe("skip");
+
+      await act(async () => {
+        await result.current.recordLike(articleId);
+      });
+
+      expect(result.current.getFeedbackType(articleId)).toBe("like");
+    });
+  });
+
+  describe("読了判定（暗黙的Like）", () => {
+    it("recordLike()でtype=likeのフィードバックが送信される", async () => {
+      const { result } = renderHook(() => useFeedback());
+      const articleId = "scp-173";
+
+      await act(async () => {
+        await result.current.recordLike(articleId);
+      });
+
       expect(mockApi.feedback.$post).toHaveBeenCalledWith({
         json: { visitorId: "test-visitor-id", articleId: "scp-173", type: "like" },
       });
@@ -104,148 +285,42 @@ describe("useFeedback", () => {
     });
 
     it("同じ記事で2回目の読了時はAPI呼び出しをスキップする", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // 1回目のLike
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
       mockApi.feedback.$post.mockClear();
 
-      // Act: 2回目のLike
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert: API呼び出しがスキップされる
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
     });
   });
 
-  describe("AC-2: スキップ（Dislike）", () => {
-    it("recordDislike()でtype=dislikeのフィードバックが送信される", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-      const articleId = "scp-173";
-
-      // Act
-      await act(async () => {
-        await result.current.recordDislike(articleId);
-      });
-
-      // Assert
-      expect(mockApi.feedback.$post).toHaveBeenCalledWith({
-        json: { visitorId: "test-visitor-id", articleId: "scp-173", type: "dislike" },
-      });
-      expect(result.current.hasRecorded(articleId)).toBe(true);
-      expect(result.current.getFeedbackType(articleId)).toBe("dislike");
-    });
-
-    it("Dislike記録後もユーザー操作はブロックされない", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-      const articleId = "scp-173";
-
-      // Act: エラー時でもresolveする
-      const startTime = Date.now();
-      await act(async () => {
-        await result.current.recordDislike(articleId);
-      });
-      const endTime = Date.now();
-
-      // Assert: 即座に完了（ブロックされない）
-      expect(endTime - startTime).toBeLessThan(100);
-      expect(result.current.hasRecorded(articleId)).toBe(true);
-    });
-  });
-
-  describe("AC-3: 重複記録防止", () => {
-    it("同じ記事に既にフィードバックがある場合はAPI呼び出しをスキップする", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-      const articleId = "scp-173";
-
-      // 1回目: Like記録
-      await act(async () => {
-        await result.current.recordLike(articleId);
-      });
-
-      expect(mockApi.feedback.$post).toHaveBeenCalledTimes(1);
-      mockApi.feedback.$post.mockClear();
-
-      // Act: 2回目: 同じ記事でDislike試行
-      await act(async () => {
-        await result.current.recordDislike(articleId);
-      });
-
-      // Assert: 優先度が低いのでスキップ（like > dislike）
-      expect(mockApi.feedback.$post).not.toHaveBeenCalled();
-      expect(result.current.getFeedbackType(articleId)).toBe("like");
-    });
-
-    it("hasRecorded()で記録済み状態を正確に確認できる", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-
-      // Assert: 初期状態
-      expect(result.current.hasRecorded("scp-173")).toBe(false);
-      expect(result.current.hasRecorded("scp-096")).toBe(false);
-
-      // Act: Like記録
-      await act(async () => {
-        await result.current.recordLike("scp-173");
-      });
-
-      // Assert: 記録後
-      expect(result.current.hasRecorded("scp-173")).toBe(true);
-      expect(result.current.hasRecorded("scp-096")).toBe(false);
-    });
-
-    it("getFeedbackType()でフィードバック種別を取得できる", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-
-      // Assert: 初期状態
-      expect(result.current.getFeedbackType("scp-173")).toBeNull();
-
-      // Act: Like記録
-      await act(async () => {
-        await result.current.recordLike("scp-173");
-      });
-
-      // Assert: 記録後
-      expect(result.current.getFeedbackType("scp-173")).toBe("like");
-    });
-  });
-
-  describe("AC-4: オフライン対応", () => {
+  describe("オフライン対応", () => {
     it("API失敗時にフィードバックをローカルキューに追加する", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Mock: API失敗
       mockApi.feedback.$post.mockRejectedValueOnce(new Error("Network error"));
 
-      // Act
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert: キューに追加
       expect(result.current.pendingCount).toBe(1);
-      expect(result.current.hasRecorded(articleId)).toBe(true); // 楽観的更新
+      expect(result.current.hasRecorded(articleId)).toBe(true);
     });
 
     it("ネットワーク復帰時にキューのフィードバックを再送信する", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Mock: 初回失敗、2回目成功
       mockApi.feedback.$post
         .mockRejectedValueOnce(new Error("Network error"))
         .mockResolvedValueOnce({
@@ -253,21 +328,17 @@ describe("useFeedback", () => {
           json: vi.fn().mockResolvedValue({ success: true }),
         });
 
-      // Act: オフライン時のLike記録
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
       expect(result.current.pendingCount).toBe(1);
 
-      // Act: オンライン復帰イベント発火
       act(() => {
         window.dispatchEvent(new Event("online"));
       });
 
-      // Assert: キューが処理される（Promiseを待つ）
       await act(async () => {
-        // フック内の非同期処理を待機
         await Promise.resolve();
       });
 
@@ -276,18 +347,15 @@ describe("useFeedback", () => {
     });
 
     it("localStorageにキューが永続化される", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
       mockApi.feedback.$post.mockRejectedValueOnce(new Error("Network error"));
 
-      // Act: オフライン時のLike記録
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert: localStorageに保存
       const stored = localStorage.getItem("scp-feedback-pending");
       expect(stored).toBeTruthy();
       const parsed = JSON.parse(stored ?? "[]") as { articleId: string; type: string }[];
@@ -297,33 +365,28 @@ describe("useFeedback", () => {
     });
   });
 
-  describe("AC-5: エラーハンドリング", () => {
+  describe("エラーハンドリング", () => {
     it("API失敗時でもユーザー操作はブロックされない", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
       mockApi.feedback.$post.mockRejectedValueOnce(new Error("Server error"));
 
-      // Act: エラー時でもresolveする
       const startTime = Date.now();
       await act(async () => {
         await result.current.recordLike(articleId);
       });
       const endTime = Date.now();
 
-      // Assert: 即座に完了（ブロックされない）
       expect(endTime - startTime).toBeLessThan(100);
       expect(result.current.hasRecorded(articleId)).toBe(true);
     });
 
     it("バックグラウンドで最大3回リトライする", async () => {
-      // Arrange
-      vi.useRealTimers(); // このテストでは実際のタイマーを使用
+      vi.useRealTimers();
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Mock: 3回失敗、4回目成功
       mockApi.feedback.$post
         .mockRejectedValueOnce(new Error("Error 1"))
         .mockRejectedValueOnce(new Error("Error 2"))
@@ -333,14 +396,12 @@ describe("useFeedback", () => {
           json: vi.fn().mockResolvedValue({ success: true }),
         });
 
-      // Act: 失敗してキューに追加
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
       expect(result.current.pendingCount).toBe(1);
 
-      // 定期処理を手動でトリガー（onlineイベントを使用）
       for (let i = 0; i < 3; i++) {
         await act(async () => {
           window.dispatchEvent(new Event("online"));
@@ -348,32 +409,26 @@ describe("useFeedback", () => {
         });
       }
 
-      // Assert: 最終的に成功
       expect(result.current.pendingCount).toBe(0);
       expect(mockApi.feedback.$post).toHaveBeenCalledTimes(4);
 
-      vi.useFakeTimers(); // 他のテストのために戻す
+      vi.useFakeTimers();
     });
 
     it("最大リトライ回数を超えるとキューから削除する", async () => {
-      // Arrange
-      vi.useRealTimers(); // このテストでは実際のタイマーを使用
-      mockApi.feedback.$post.mockReset(); // モックをリセット
+      vi.useRealTimers();
+      mockApi.feedback.$post.mockReset();
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Mock: 常に失敗
       mockApi.feedback.$post.mockRejectedValue(new Error("Permanent error"));
 
-      // Act: 失敗してキューに追加（初回呼び出し）
       await act(async () => {
         await result.current.recordLike(articleId);
       });
 
       expect(result.current.pendingCount).toBe(1);
 
-      // 定期処理を手動でトリガー（onlineイベントを使用）
-      // MAX_RETRIES=3なので、retryCount: 0→1→2→3（4回目で削除）
       for (let i = 0; i < 4; i++) {
         await act(async () => {
           window.dispatchEvent(new Event("online"));
@@ -381,26 +436,26 @@ describe("useFeedback", () => {
         });
       }
 
-      // Assert: キューから削除
       expect(result.current.pendingCount).toBe(0);
-      // 初回API呼び出し + 4回のprocessQueue試行
       expect(mockApi.feedback.$post).toHaveBeenCalledTimes(5);
 
-      vi.useFakeTimers(); // 他のテストのために戻す
+      vi.useFakeTimers();
     });
   });
 
-  describe("AC-6: フィードバック種別の優先度", () => {
-    it("favorite > like > dislike の優先度で上書きされる", async () => {
-      // Arrange
+  describe("フィードバック種別の優先度", () => {
+    it("favorite > like > skip の優先度で上書きされる", async () => {
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Act: dislike → like → favorite
       await act(async () => {
-        await result.current.recordDislike(articleId);
+        await result.current.recordSkip(articleId, {
+          scrollDepth: 5,
+          dwellTime: 3,
+          interestLevel: "skip",
+        });
       });
-      expect(result.current.getFeedbackType(articleId)).toBe("dislike");
+      expect(result.current.getFeedbackType(articleId)).toBe("skip");
 
       await act(async () => {
         await result.current.recordLike(articleId);
@@ -414,11 +469,9 @@ describe("useFeedback", () => {
     });
 
     it("低優先度のフィードバックは高優先度を上書きしない", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Act: favorite → like試行
       await act(async () => {
         await result.current.recordFavorite(articleId);
       });
@@ -429,17 +482,14 @@ describe("useFeedback", () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert: favoriteのまま（likeは無視）
       expect(result.current.getFeedbackType(articleId)).toBe("favorite");
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
     });
 
     it("同じ優先度のフィードバックは重複記録されない", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Act: like → like
       await act(async () => {
         await result.current.recordLike(articleId);
       });
@@ -450,70 +500,20 @@ describe("useFeedback", () => {
         await result.current.recordLike(articleId);
       });
 
-      // Assert: 2回目は無視
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
-    });
-
-    it("dislikeはlike/favoriteで上書きされる", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-      const articleId = "scp-173";
-
-      // dislikeを記録
-      await act(async () => {
-        await result.current.recordDislike(articleId);
-      });
-      expect(result.current.getFeedbackType(articleId)).toBe("dislike");
-
-      // likeで上書き
-      await act(async () => {
-        await result.current.recordLike(articleId);
-      });
-      expect(result.current.getFeedbackType(articleId)).toBe("like");
-    });
-
-    it("likeはfavoriteで上書きされるがdislikeでは上書きされない", async () => {
-      // Arrange
-      const { result } = renderHook(() => useFeedback());
-      const articleId = "scp-173";
-
-      // likeを記録
-      await act(async () => {
-        await result.current.recordLike(articleId);
-      });
-      expect(result.current.getFeedbackType(articleId)).toBe("like");
-
-      // dislikeでは上書きされない
-      mockApi.feedback.$post.mockClear();
-      await act(async () => {
-        await result.current.recordDislike(articleId);
-      });
-      expect(result.current.getFeedbackType(articleId)).toBe("like");
-      expect(mockApi.feedback.$post).not.toHaveBeenCalled();
-
-      // favoriteで上書き
-      await act(async () => {
-        await result.current.recordFavorite(articleId);
-      });
-      expect(result.current.getFeedbackType(articleId)).toBe("favorite");
     });
   });
 
   describe("recordFavorite", () => {
     it("recordFavorite()でローカル状態が更新される（APIは呼び出さない）", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
       const articleId = "scp-173";
 
-      // Act
       await act(async () => {
         await result.current.recordFavorite(articleId);
       });
 
-      // Assert: favoriteはfeedback APIではなくfavorites APIで管理するため、ここでは呼び出さない
-      // 006-02-06（お気に入りボタン）で別途実装される
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
-      // ローカル状態は更新される（優先度管理のため）
       expect(result.current.hasRecorded(articleId)).toBe(true);
       expect(result.current.getFeedbackType(articleId)).toBe("favorite");
     });
@@ -521,31 +521,58 @@ describe("useFeedback", () => {
 
   describe("pendingCount", () => {
     it("pendingCountで保留中の件数を取得できる", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
 
-      // Assert: 初期状態
       expect(result.current.pendingCount).toBe(0);
 
-      // Mock: API失敗
       mockApi.feedback.$post.mockRejectedValue(new Error("Network error"));
 
-      // Act: 複数のフィードバックを記録
       await act(async () => {
         await result.current.recordLike("scp-173");
       });
       expect(result.current.pendingCount).toBe(1);
 
       await act(async () => {
-        await result.current.recordDislike("scp-682");
+        await result.current.recordSkip("scp-682", {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
       });
       expect(result.current.pendingCount).toBe(2);
     });
   });
 
-  describe("エッジケース", () => {
+  describe("recordSkip エッジケース", () => {
+    it("scrollDepth=0%, dwellTime=0sでも正常に記録される", async () => {
+      const { result } = renderHook(() => useFeedback());
+
+      await act(async () => {
+        await result.current.recordSkip("scp-173", {
+          scrollDepth: 0,
+          dwellTime: 0,
+          interestLevel: "skip",
+        });
+      });
+
+      expect(mockApi.feedback.$post).toHaveBeenCalled();
+    });
+
+    it("scrollDepth=100%, dwellTime=1000sの極端な値でも正常に記録される", async () => {
+      const { result } = renderHook(() => useFeedback());
+
+      await act(async () => {
+        await result.current.recordSkip("scp-173", {
+          scrollDepth: 100,
+          dwellTime: 1000,
+          interestLevel: "like",
+        });
+      });
+
+      expect(mockApi.feedback.$post).toHaveBeenCalled();
+    });
+
     it("visitorIdがない場合はAPI呼び出しをスキップする", async () => {
-      // Arrange
       mockUseVisitorId.mockReturnValue({
         visitorId: null,
         isLoading: true,
@@ -556,26 +583,44 @@ describe("useFeedback", () => {
 
       const { result } = renderHook(() => useFeedback());
 
-      // Act
       await act(async () => {
-        await result.current.recordLike("scp-173");
+        await result.current.recordSkip("scp-173", {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
       });
 
-      // Assert: API呼び出しがスキップされる
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
     });
 
     it("空文字のarticleIdの場合はAPI呼び出しをスキップする", async () => {
-      // Arrange
       const { result } = renderHook(() => useFeedback());
 
-      // Act
       await act(async () => {
-        await result.current.recordLike("");
+        await result.current.recordSkip("", {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
       });
 
-      // Assert: API呼び出しがスキップされる
       expect(mockApi.feedback.$post).not.toHaveBeenCalled();
+    });
+
+    it("API失敗時にキューに追加される", async () => {
+      const { result } = renderHook(() => useFeedback());
+      mockApi.feedback.$post.mockRejectedValueOnce(new Error("Network error"));
+
+      await act(async () => {
+        await result.current.recordSkip("scp-173", {
+          scrollDepth: 30,
+          dwellTime: 15,
+          interestLevel: "neutral",
+        });
+      });
+
+      expect(result.current.pendingCount).toBe(1);
     });
   });
 });

--- a/apps/web/src/app/(main)/recommend/_hooks/useFeedback.ts
+++ b/apps/web/src/app/(main)/recommend/_hooks/useFeedback.ts
@@ -1,19 +1,20 @@
 /**
  * @file useFeedback フック
- * @description Like/Dislike/Favoriteフィードバックを記録するフック
- * @see specs/006-frontend/006-02-article-reader/006-02-05.md
+ * @description Like/Skip/Favoriteフィードバックを記録するフック
+ * @see specs/006-frontend/006-05-transition-ux/006-05-06.md
  */
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { api } from "@/shared/lib/api-client";
 import { useVisitorId } from "@/shared/hooks/useVisitorId";
-import type { FeedbackType, UseFeedbackResult } from "../_types";
+import type { FeedbackType, SkipMetadata, UseFeedbackResult } from "../_types";
 
 /** 保留中のフィードバック */
 interface PendingFeedback {
   articleId: string;
   type: FeedbackType;
+  metadata?: SkipMetadata;
   retryCount: number;
   timestamp: number;
 }
@@ -22,12 +23,28 @@ const STORAGE_KEY = "scp-feedback-pending";
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 5000;
 
-/** 優先度: favorite > like > dislike */
+/** 優先度: favorite > like > skip */
 const PRIORITY: Record<FeedbackType, number> = {
   favorite: 3,
   like: 2,
-  dislike: 1,
+  skip: 1,
 };
+
+/**
+ * interest_levelを算出する
+ *
+ * AC-3: scrollDepth < 10 AND dwellTime < 5 → "skip"
+ * AC-5: scrollDepth > 50 AND dwellTime > 30 → "like"
+ * AC-4: それ以外 → "neutral"
+ */
+export function calculateInterestLevel(
+  scrollDepth: number,
+  dwellTime: number
+): "skip" | "neutral" | "like" {
+  if (scrollDepth < 10 && dwellTime < 5) return "skip";
+  if (scrollDepth > 50 && dwellTime > 30) return "like";
+  return "neutral";
+}
 
 /**
  * ローカルストレージから保留中のフィードバックを読み込む
@@ -64,20 +81,23 @@ export function useFeedback(): UseFeedbackResult {
   }, [pendingQueue]);
 
   // フィードバック送信（内部）
-  // NOTE: feedback APIは like/dislike のみサポート。favoriteは別APIで管理するため、ここでは成功とみなす
+  // NOTE: feedback APIは like/skip のみサポート。favoriteは別APIで管理するため、ここでは成功とみなす
   const sendFeedback = useCallback(
-    async (articleId: string, type: FeedbackType): Promise<boolean> => {
+    async (articleId: string, type: FeedbackType, metadata?: SkipMetadata): Promise<boolean> => {
       if (!visitorId) return false;
 
       // favoriteはfeedback APIではなく別途favorites APIで管理
-      // 006-02-06（お気に入りボタン）で実装予定
       if (type === "favorite") {
         return true;
       }
 
       try {
+        const json: Record<string, unknown> = { visitorId, articleId, type };
+        if (metadata) {
+          json.metadata = metadata;
+        }
         const res = await api.feedback.$post({
-          json: { visitorId, articleId, type },
+          json: json as Parameters<typeof api.feedback.$post>[0]["json"],
         });
         return res.ok;
       } catch {
@@ -94,7 +114,7 @@ export function useFeedback(): UseFeedbackResult {
     processingRef.current = true;
 
     const [current, ...rest] = pendingQueue;
-    const success = await sendFeedback(current.articleId, current.type);
+    const success = await sendFeedback(current.articleId, current.type, current.metadata);
 
     if (success) {
       // 成功: キューから削除
@@ -133,7 +153,7 @@ export function useFeedback(): UseFeedbackResult {
 
   // フィードバック記録（共通）
   const recordFeedback = useCallback(
-    async (articleId: string, type: FeedbackType) => {
+    async (articleId: string, type: FeedbackType, metadata?: SkipMetadata) => {
       // バリデーション
       if (!articleId || !visitorId) return;
 
@@ -148,13 +168,13 @@ export function useFeedback(): UseFeedbackResult {
       setRecordedFeedbacks((prev) => new Map(prev).set(articleId, type));
 
       // API送信を試行
-      const success = await sendFeedback(articleId, type);
+      const success = await sendFeedback(articleId, type, metadata);
 
       if (!success) {
         // 失敗時はキューに追加
         setPendingQueue((prev) => [
           ...prev.filter((p) => p.articleId !== articleId),
-          { articleId, type, retryCount: 0, timestamp: Date.now() },
+          { articleId, type, metadata, retryCount: 0, timestamp: Date.now() },
         ]);
       }
     },
@@ -167,8 +187,8 @@ export function useFeedback(): UseFeedbackResult {
     [recordFeedback]
   );
 
-  const recordDislike = useCallback(
-    (articleId: string) => recordFeedback(articleId, "dislike"),
+  const recordSkip = useCallback(
+    (articleId: string, metadata: SkipMetadata) => recordFeedback(articleId, "skip", metadata),
     [recordFeedback]
   );
 
@@ -189,7 +209,7 @@ export function useFeedback(): UseFeedbackResult {
 
   return {
     recordLike,
-    recordDislike,
+    recordSkip,
     recordFavorite,
     hasRecorded,
     getFeedbackType,

--- a/apps/web/src/app/(main)/recommend/_types/index.ts
+++ b/apps/web/src/app/(main)/recommend/_types/index.ts
@@ -68,14 +68,24 @@ export interface UseInfiniteArticlesResult {
 }
 
 /** フィードバック種別 */
-export type FeedbackType = "like" | "dislike" | "favorite";
+export type FeedbackType = "like" | "skip" | "favorite";
+
+/** スキップメタデータ */
+export interface SkipMetadata {
+  /** スクロール深度（0-100） */
+  scrollDepth: number;
+  /** 滞在時間（秒） */
+  dwellTime: number;
+  /** 興味度 */
+  interestLevel: "skip" | "neutral" | "like";
+}
 
 /** useFeedback フックの戻り値 */
 export interface UseFeedbackResult {
   /** Like記録（暗黙的Like） */
   recordLike: (articleId: string) => Promise<void>;
-  /** Dislike記録（スキップ） */
-  recordDislike: (articleId: string) => Promise<void>;
+  /** Skip記録（暗黙的フィードバック + メタデータ） */
+  recordSkip: (articleId: string, metadata: SkipMetadata) => Promise<void>;
   /** Favorite記録（明示的お気に入り） */
   recordFavorite: (articleId: string) => Promise<void>;
   /** 記事のフィードバック済み状態を確認 */

--- a/apps/web/src/app/(main)/recommend/page.tsx
+++ b/apps/web/src/app/(main)/recommend/page.tsx
@@ -2,12 +2,13 @@
  * @file 記事閲覧ページ
  * @description /recommend ページのメインコンポーネント
  * @see specs/006-frontend/006-02-article-reader/006-02-07.md
+ * @see specs/006-frontend/006-05-transition-ux/006-05-06.md
  */
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useInfiniteArticles } from "./_hooks/useInfiniteArticles";
-import { useFeedback } from "./_hooks/useFeedback";
+import { useFeedback, calculateInterestLevel } from "./_hooks/useFeedback";
 import { useArticleFavorite } from "./_hooks/useArticleFavorite";
 import { useHistory } from "@/app/(main)/history/_hooks/useHistory";
 import { ArticleWebView, type ArticleContent } from "./_components/ArticleWebView";
@@ -34,12 +35,17 @@ const TRANSITION_DURATION_MS = 500;
  * AC-6 (007): 下部到達時のLike記録 + 自動遷移
  * AC-8 (007): 過去記事のメモリ解放（最大2 iframe）
  * AC-9 (007): 遷移中の操作制御（連打防止）
+ *
+ * 006-05-06 追加:
+ * AC-1 (006): Dislike記録の廃止 → Skip + メタデータ
+ * AC-6 (006): スクロール深度の計測
+ * AC-7 (006): 滞在時間の計測
  */
 export default function RecommendPage() {
   const { articles, currentIndex, isLoading, error, isEmpty, goToNext, refetch } =
     useInfiniteArticles();
 
-  const { recordLike, recordDislike } = useFeedback();
+  const { recordLike, recordSkip } = useFeedback();
   const currentArticle = articles[currentIndex] as (typeof articles)[number] | undefined;
   const nextArticle = articles[currentIndex + 1] as (typeof articles)[number] | undefined;
   const { isFavorited, toggleFavorite } = useArticleFavorite({
@@ -50,6 +56,25 @@ export default function RecommendPage() {
   const [isRetrying, setIsRetrying] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const transitioningRef = useRef(false);
+
+  // AC-6 (006-05-06): スクロール深度の追跡（最大到達深度を保持）
+  const maxScrollDepthRef = useRef(0);
+
+  // AC-7 (006-05-06): 滞在時間の計測
+  const articleStartTimeRef = useRef(0);
+
+  // 記事が変わったらスクロール深度・滞在時間をリセット
+  useEffect(() => {
+    maxScrollDepthRef.current = 0;
+    articleStartTimeRef.current = Date.now();
+  }, [currentIndex]);
+
+  // スクロール深度の変更ハンドラー（AC-6: 最大到達深度を保持）
+  const handleScrollChange = useCallback((percentage: number) => {
+    if (percentage > maxScrollDepthRef.current) {
+      maxScrollDepthRef.current = percentage;
+    }
+  }, []);
 
   // 再試行ハンドラー
   const handleRetry = useCallback(() => {
@@ -83,14 +108,22 @@ export default function RecommendPage() {
     };
   }, [isTransitioning, completeTransition]);
 
-  // AC-5 (007): 次へボタンハンドラー（即座に遷移 + AC-9: 遷移中ブロック）
+  // AC-5 (007) + AC-1/AC-2 (006-05-06): 次へボタンハンドラー
+  // Dislike → Skip + メタデータに変更
   const handleNext = useCallback(() => {
     if (transitioningRef.current) return; // AC-9: 遷移中は操作をブロック
     if (currentArticle) {
-      void recordDislike(currentArticle.id);
+      const dwellTime = (Date.now() - articleStartTimeRef.current) / 1000;
+      const currentScrollDepth = maxScrollDepthRef.current;
+      const interestLevel = calculateInterestLevel(currentScrollDepth, dwellTime);
+      void recordSkip(currentArticle.id, {
+        scrollDepth: currentScrollDepth,
+        dwellTime,
+        interestLevel,
+      });
     }
     goToNext(); // AC-5: 即座に遷移（既存挙動維持）
-  }, [currentArticle, recordDislike, goToNext]);
+  }, [currentArticle, recordSkip, goToNext]);
 
   // お気に入りボタンハンドラー
   const handleFavorite = useCallback(() => {
@@ -152,6 +185,7 @@ export default function RecommendPage() {
           url={currentArticle.url}
           articleId={currentArticle.id}
           onScrollEnd={handleScrollEnd}
+          onScrollChange={handleScrollChange}
           onSkip={goToNext}
           onContentLoaded={handleContentLoaded}
         />

--- a/packages/shared/src/recommendation/profiler.ts
+++ b/packages/shared/src/recommendation/profiler.ts
@@ -154,7 +154,7 @@ export class PreferenceProfiler {
    * @returns タグ名 → 重み値のマップ
    */
   private async calculateTagWeights(
-    feedbacks: { articleId: string; type: "like" | "dislike" }[],
+    feedbacks: { articleId: string; type: "like" | "dislike" | "skip" }[],
     viewHistories: { articleId: string; duration?: number }[]
   ): Promise<Record<string, number>> {
     const weights: Record<string, number> = {};

--- a/packages/shared/src/storage/types.test.ts
+++ b/packages/shared/src/storage/types.test.ts
@@ -228,8 +228,8 @@ describe("004-01-01: ストレージ抽象化レイヤー", () => {
         createdAt: "2026-01-20T00:00:00Z",
       };
 
-      expectTypeOf(like.type).toEqualTypeOf<"like" | "dislike">();
-      expectTypeOf(dislike.type).toEqualTypeOf<"like" | "dislike">();
+      expectTypeOf(like.type).toEqualTypeOf<"like" | "dislike" | "skip">();
+      expectTypeOf(dislike.type).toEqualTypeOf<"like" | "dislike" | "skip">();
     });
   });
 

--- a/packages/shared/src/storage/types.ts
+++ b/packages/shared/src/storage/types.ts
@@ -198,7 +198,7 @@ export interface Feedback {
   articleId: string;
 
   /** フィードバック種別 */
-  type: "like" | "dislike";
+  type: "like" | "dislike" | "skip";
 
   /** 作成日時（ISO 8601形式） */
   createdAt: string;

--- a/specs/006-frontend/006-05-transition-ux/006-05-06.md
+++ b/specs/006-frontend/006-05-transition-ux/006-05-06.md
@@ -7,7 +7,7 @@
 
 ## ステータス
 
-- **status**: pending
+- **status**: completed
 
 ## 親Story
 
@@ -58,55 +58,55 @@ interest_level = f(scrollDepth, dwellTime)
 
 ### AC-1: Dislike記録の廃止
 
-- [ ] WHEN ユーザーが「次へ」ボタンをタップした際
+- [x] WHEN ユーザーが「次へ」ボタンをタップした際
       THEN type=dislikeのフィードバックが記録されない
 
 ### AC-2: 暗黙的フィードバックの記録
 
-- [ ] WHEN ユーザーが「次へ」ボタンをタップした際
+- [x] WHEN ユーザーが「次へ」ボタンをタップした際
       THEN スクロール深度（scrollDepth: 0-100）と滞在時間（dwellTime: 秒）が計測される
       AND interest_level（skip/neutral/like）が算出される
       AND POST /feedback APIにtype="skip"とメタデータ（scrollDepth, dwellTime）が送信される
 
 ### AC-3: 低興味判定（skip）
 
-- [ ] WHEN ユーザーが「次へ」ボタンをタップした際
+- [x] WHEN ユーザーが「次へ」ボタンをタップした際
       GIVEN scrollDepthが10%未満かつdwellTimeが5秒未満の場合
       THEN interest_level="skip"として記録される
 
 ### AC-4: 中興味判定（neutral）
 
-- [ ] WHEN ユーザーが「次へ」ボタンをタップした際
+- [x] WHEN ユーザーが「次へ」ボタンをタップした際
       GIVEN scrollDepthが10-50%またはdwellTimeが5-30秒の場合
       THEN interest_level="neutral"として記録される
 
 ### AC-5: 高興味判定（like相当）
 
-- [ ] WHEN ユーザーが「次へ」ボタンをタップした際
+- [x] WHEN ユーザーが「次へ」ボタンをタップした際
       GIVEN scrollDepthが50%超かつdwellTimeが30秒超の場合
       THEN interest_level="like"として記録される（暗黙的Like相当）
 
 ### AC-6: スクロール深度の計測
 
-- [ ] WHERE 記事閲覧中において
+- [x] WHERE 記事閲覧中において
       THE SYSTEM SHALL iframe内のスクロール位置を継続的に追跡する
       AND 最大到達スクロール深度を保持する（スクロールバックしても減らない）
 
 ### AC-7: 滞在時間の計測
 
-- [ ] WHERE 記事閲覧中において
+- [x] WHERE 記事閲覧中において
       THE SYSTEM SHALL 記事表示開始時刻からの経過時間を計測する
       AND 「次へ」タップ時の滞在時間を取得する
 
 ### AC-8: 既存Like/Favoriteとの優先度
 
-- [ ] WHERE フィードバック優先度において
+- [x] WHERE フィードバック優先度において
       IF 既にLikeまたはFavoriteが記録された記事で「次へ」がタップされた場合
       THE SYSTEM SHALL 暗黙的フィードバックの送信をスキップする（優先度: favorite > like > skip/neutral）
 
 ### AC-9: API後方互換性
 
-- [ ] WHERE POST /feedback APIにおいて
+- [x] WHERE POST /feedback APIにおいて
       THE SYSTEM SHALL 既存の "like" | "dislike" | "favorite" 型に加えて "skip" 型を受け付ける
       AND メタデータ（scrollDepth, dwellTime, interestLevel）をオプショナルフィールドとして受け付ける
 
@@ -195,26 +195,26 @@ interface FeedbackRequest {
 
 ### useFeedback ユニットテスト
 
-- [ ] recordSkip()でtype=skipのフィードバックが送信される
-- [ ] recordDislike()が存在しない（削除確認）
-- [ ] scrollDepth=5%, dwellTime=3sでinterestLevel="skip"が算出される
-- [ ] scrollDepth=30%, dwellTime=15sでinterestLevel="neutral"が算出される
-- [ ] scrollDepth=70%, dwellTime=45sでinterestLevel="like"が算出される
-- [ ] 境界値: scrollDepth=10%, dwellTime=5sでinterestLevel="neutral"が算出される
-- [ ] 境界値: scrollDepth=50%, dwellTime=30sでinterestLevel="neutral"が算出される
-- [ ] 既にLike記録済みの記事でrecordSkip()がスキップされる
-- [ ] メタデータ（scrollDepth, dwellTime, interestLevel）がAPIリクエストに含まれる
+- [x] recordSkip()でtype=skipのフィードバックが送信される
+- [x] recordDislike()が存在しない（削除確認）
+- [x] scrollDepth=5%, dwellTime=3sでinterestLevel="skip"が算出される
+- [x] scrollDepth=30%, dwellTime=15sでinterestLevel="neutral"が算出される
+- [x] scrollDepth=70%, dwellTime=45sでinterestLevel="like"が算出される
+- [x] 境界値: scrollDepth=10%, dwellTime=5sでinterestLevel="neutral"が算出される
+- [x] 境界値: scrollDepth=50%, dwellTime=30sでinterestLevel="neutral"が算出される
+- [x] 既にLike記録済みの記事でrecordSkip()がスキップされる
+- [x] メタデータ（scrollDepth, dwellTime, interestLevel）がAPIリクエストに含まれる
 
 ### page.tsx 結合テスト
 
-- [ ] 「次へ」ボタンでrecordSkipが呼ばれる（recordDislikeではない）
-- [ ] scrollDepthとdwellTimeがmetadataに正しく含まれる
+- [x] 「次へ」ボタンでrecordSkipが呼ばれる（recordDislikeではない）
+- [x] scrollDepthとdwellTimeがmetadataに正しく含まれる
 
 ### フィードバックAPI テスト
 
-- [ ] type="skip"のリクエストが正常に処理される
-- [ ] metadataフィールドがオプショナルで受け付けられる
-- [ ] type="dislike"が後方互換性のために引き続き受け付けられる
+- [x] type="skip"のリクエストが正常に処理される
+- [x] metadataフィールドがオプショナルで受け付けられる
+- [x] type="dislike"が後方互換性のために引き続き受け付けられる
 
 ## 成果物
 

--- a/specs/006-frontend/006-05-transition-ux/subtask-list.md
+++ b/specs/006-frontend/006-05-transition-ux/subtask-list.md
@@ -7,7 +7,7 @@
 | [006-05-03](./006-05-03.md) | 遷移ヘッダーカードコンポーネント          | TransitionCard新規実装                                      | pending    |
 | [006-05-04](./006-05-04.md) | Cascade Prefetch（3スロットiframeプール） | デュアルiframe→3スロットプール                              | completed  |
 | [006-05-05](./006-05-05.md) | プログレスバー削除                        | FloatingUIからProgressBar削除                               | completed  |
-| [006-05-06](./006-05-06.md) | フィードバック判定改善                    | Dislike廃止、暗黙的フィードバック導入                       | pending    |
+| [006-05-06](./006-05-06.md) | フィードバック判定改善                    | Dislike廃止、暗黙的フィードバック導入                       | completed  |
 | [006-05-07](./006-05-07.md) | 遷移UX統合・結合テスト                    | page.tsxに全変更を統合                                      | pending    |
 
 ## 依存関係


### PR DESCRIPTION
## Summary
This PR implements AC-9 (Skip型対応) by replacing the "dislike" feedback type with "skip" and adding optional metadata support for tracking user engagement metrics (scroll depth, dwell time, interest level).

## Key Changes

### Backend API Changes
- **Schema**: Updated `recordFeedbackSchema` to accept "skip" type instead of "dislike" and added optional `metadata` field with validation for `scrollDepth` (0-100), `dwellTime` (≥0), and `interestLevel` enum
- **Service & Repository**: Updated type definitions to support "like", "dislike" (for backward compatibility), and "skip"
- **Routes**: Updated documentation to reflect skip type support
- **Tests**: Added comprehensive test suite for skip type validation and backward compatibility with dislike

### Frontend Changes
- **useFeedback Hook**: 
  - Replaced `recordDislike()` with `recordSkip(articleId, metadata)` 
  - Added `calculateInterestLevel()` function to determine interest level based on scroll depth and dwell time thresholds
  - Updated priority system: `favorite > like > skip`
  - Enhanced pending queue to store metadata for offline support

- **RecommendPage Component**:
  - Added scroll depth tracking (`maxScrollDepthRef`) to capture maximum scroll percentage
  - Added dwell time tracking (`articleStartTimeRef`) to measure time spent on article
  - Updated "next" button handler to calculate and send skip metadata instead of dislike
  - Added `onScrollChange` callback to track scroll depth changes

- **Types**: Updated `FeedbackType` and added new `SkipMetadata` interface

### Test Updates
- Updated page tests to verify skip metadata is passed correctly with scroll depth, dwell time, and interest level
- Added schema validation tests for skip type and metadata constraints
- Updated useFeedback hook tests with new AC numbering and skip-specific test cases
- Added interest level calculation tests for skip/neutral/like boundaries

### Backward Compatibility
- API continues to accept "dislike" type for backward compatibility
- Existing "like" feedback continues to work unchanged
- Favorite functionality remains independent

## Implementation Details
- Interest level calculation: `skip` (scrollDepth < 10 AND dwellTime < 5), `like` (scrollDepth > 50 AND dwellTime > 30), `neutral` (otherwise)
- Metadata is optional in API schema but required when calling `recordSkip()`
- Skip feedback has lower priority than like/favorite and won't overwrite existing feedback
- Offline queue now persists metadata for proper retry behavior

https://claude.ai/code/session_01PA2V7szeLBRh612nLki7oH