### PR TITLE
fix(api): get_object_class関数のカラム名をcanonical_valueに修正

### DIFF
--- a/supabase/migrations/20260206000001_add_object_class_rating_to_rpc.sql
+++ b/supabase/migrations/20260206000001_add_object_class_rating_to_rpc.sql
@@ -17,10 +17,10 @@ RETURNS TEXT AS $$
 DECLARE
   oc TEXT;
 BEGIN
-  SELECT td.value INTO oc
+  SELECT td.canonical_value INTO oc
   FROM tag_dictionary td
   WHERE td.category = 'object_class'
-    AND td.value = ANY(article_tags)
+    AND td.canonical_value = ANY(article_tags)
   LIMIT 1;
   RETURN oc;
 END;

--- a/supabase/migrations/20260207000001_fix_get_object_class_column_name.sql
+++ b/supabase/migrations/20260207000001_fix_get_object_class_column_name.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- Fix: get_object_class関数のカラム名修正
+-- ============================================
+-- 20260206000001で作成されたget_object_class関数が
+-- tag_dictionaryテーブルのカラム名を誤って td.value と参照していた。
+-- 正しいカラム名は td.canonical_value。
+-- Vercelデプロイ環境で推薦API (/api/recommend) が500エラーを返す原因。
+-- PostgreSQL error: column td.value does not exist
+-- ============================================
+
+CREATE OR REPLACE FUNCTION get_object_class(article_tags TEXT[])
+RETURNS TEXT AS $$
+DECLARE
+  oc TEXT;
+BEGIN
+  SELECT td.canonical_value INTO oc
+  FROM tag_dictionary td
+  WHERE td.category = 'object_class'
+    AND td.canonical_value = ANY(article_tags)
+  LIMIT 1;
+  RETURN oc;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION get_object_class IS 'scp_articles.tagsからオブジェクトクラスを抽出。tag_dictionaryとの突合で判定。';


### PR DESCRIPTION
tag_dictionaryテーブルの正しいカラム名はcanonical_valueだが、
get_object_class関数がtd.valueを参照していたため推薦APIが500エラーを返していた。
(PostgreSQL error: column td.value does not exist)

https://claude.ai/code/session_015d6tVgYFgKQH7BDy45qyC3