### PR TITLE
fix(db): get_object_class関数の大文字小文字不一致を修正

### DIFF
--- a/supabase/migrations/20260206000001_add_object_class_rating_to_rpc.sql
+++ b/supabase/migrations/20260206000001_add_object_class_rating_to_rpc.sql
@@ -20,7 +20,7 @@ BEGIN
   SELECT td.canonical_value INTO oc
   FROM tag_dictionary td
   WHERE td.category = 'object_class'
-    AND td.canonical_value = ANY(article_tags)
+    AND LOWER(td.canonical_value) = ANY(article_tags)
   LIMIT 1;
   RETURN oc;
 END;

--- a/supabase/migrations/20260207000001_fix_get_object_class_column_name.sql
+++ b/supabase/migrations/20260207000001_fix_get_object_class_column_name.sql
@@ -16,7 +16,7 @@ BEGIN
   SELECT td.canonical_value INTO oc
   FROM tag_dictionary td
   WHERE td.category = 'object_class'
-    AND td.canonical_value = ANY(article_tags)
+    AND LOWER(td.canonical_value) = ANY(article_tags)
   LIMIT 1;
   RETURN oc;
 END;

--- a/supabase/migrations/20260207000002_fix_get_object_class_case_insensitive.sql
+++ b/supabase/migrations/20260207000002_fix_get_object_class_case_insensitive.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- Fix: get_object_class関数の大文字小文字不一致を修正
+-- ============================================
+-- scp_articles.tags はWikiから取得した小文字タグ（例: 'euclid', 'safe'）。
+-- tag_dictionary.canonical_value は大文字（例: 'EUCLID', 'SAFE'）。
+-- 従来のget_object_classは大文字小文字を区別する比較（= ANY）を使用しており、
+-- 常にNULLを返していた。
+-- LOWER()を使用して大文字小文字を無視する比較に修正。
+-- ============================================
+
+CREATE OR REPLACE FUNCTION get_object_class(article_tags TEXT[])
+RETURNS TEXT AS $$
+DECLARE
+  oc TEXT;
+BEGIN
+  SELECT td.canonical_value INTO oc
+  FROM tag_dictionary td
+  WHERE td.category = 'object_class'
+    AND LOWER(td.canonical_value) = ANY(article_tags)
+  LIMIT 1;
+  RETURN oc;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION get_object_class IS 'scp_articles.tagsからオブジェクトクラスを抽出。tag_dictionaryとの大文字小文字無視の突合で判定。';


### PR DESCRIPTION
scp_articles.tagsは小文字（例: 'euclid'）、tag_dictionary.canonical_valueは
大文字（例: 'EUCLID'）のため、PostgreSQLの大文字小文字区別する比較（=）で
常にNULLが返されていた。LOWER()を適用して一致するよう修正。

https://claude.ai/code/session_018gQpifahnfasWbY2MWe78k