### PR TITLE
fix(recommend): スケルトンUIからプログレスバーを削除

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/SkeletonLoader/index.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/SkeletonLoader/index.tsx
@@ -35,9 +35,6 @@ export function SkeletonLoader() {
 
       {/* 下部UIのスケルトン */}
       <div className="fixed inset-x-0 bottom-0 z-nav flex flex-col items-center gap-3 pb-8">
-        {/* ProgressBar スケルトン */}
-        <div className="h-1 w-48 animate-pulse rounded-sm bg-gray-200" />
-
         {/* PillNav スケルトン */}
         <div className="flex h-16 w-36 animate-pulse items-center justify-center gap-6 rounded-[50px] bg-gray-200/50" />
       </div>


### PR DESCRIPTION
推薦画面の初期ローディング時に表示されるスケルトンUIからプログレスバーのスケルトン要素を削除。
実際のUIではプログレスバーが非表示のため、スケルトンにも不要。

https://claude.ai/code/session_019X9VPe69b2kf75eLvUUXsv