### PR TITLE
Add foreign key constraint from favorites to scp_articles

### DIFF
--- a/supabase/migrations/20260208000002_add_favorites_article_fk.sql
+++ b/supabase/migrations/20260208000002_add_favorites_article_fk.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- favorites.article_id に scp_articles への外部キー制約を追加
+-- ============================================
+-- favoritesテーブルの article_id に FK制約がないため、
+-- Supabase PostgREST の暗黙的JOIN（scp_articles(title, rating, tags)）が
+-- リレーションシップを解決できず500エラーになる問題を修正。
+-- ============================================
+
+ALTER TABLE favorites
+  ADD CONSTRAINT fk_favorites_article
+  FOREIGN KEY (article_id)
+  REFERENCES scp_articles(id)
+  ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
Adds a missing foreign key constraint from the `favorites.article_id` column to `scp_articles.id` to fix implicit JOIN resolution issues in Supabase PostgREST.

## Changes
- Added foreign key constraint `fk_favorites_article` on `favorites.article_id` referencing `scp_articles(id)`
- Configured cascade delete behavior to automatically remove favorite records when an article is deleted

## Details
The `favorites` table was missing a foreign key constraint on the `article_id` column, which prevented Supabase PostgREST from resolving implicit relationships when querying related article fields (title, rating, tags). This caused 500 errors when attempting to fetch favorites with their associated article data.

The constraint now enables proper relationship resolution and maintains referential integrity across the database.

https://claude.ai/code/session_012GcgUfmkdViRdgCKHpK82X