### PR TITLE
Refactor wiki-proxy link rewriting to use /api/wiki-proxy/ path

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -30,7 +30,7 @@ describe("GET /wiki-proxy/*", () => {
   }
 
   describe("絶対パスリンクの書き換え", () => {
-    it("ドメインなし絶対パスリンクが /wiki/ プレフィックス付きに書き換えられる", async () => {
+    it("ドメインなし絶対パスリンクが /api/wiki-proxy/ 経由に書き換えられる", async () => {
       // Arrange
       const html = `<html><head></head><body><a href="/scp-456">SCP-456</a></body></html>`;
       global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
@@ -42,7 +42,7 @@ describe("GET /wiki-proxy/*", () => {
       const text = await res.text();
 
       // Assert
-      expect(text).toContain('href="/wiki/scp-456"');
+      expect(text).toContain('href="/api/wiki-proxy/scp-456"');
       expect(text).not.toContain('href="/scp-456"');
     });
 
@@ -58,7 +58,7 @@ describe("GET /wiki-proxy/*", () => {
       const text = await res.text();
 
       // Assert
-      expect(text).toContain('href="/wiki/hoge-fuga"');
+      expect(text).toContain('href="/api/wiki-proxy/hoge-fuga"');
     });
 
     it("複数の絶対パスリンクが全て書き換えられる", async () => {
@@ -77,14 +77,14 @@ describe("GET /wiki-proxy/*", () => {
       const text = await res.text();
 
       // Assert
-      expect(text).toContain('href="/wiki/scp-173"');
-      expect(text).toContain('href="/wiki/scp-682"');
-      expect(text).toContain('href="/wiki/taboo"');
+      expect(text).toContain('href="/api/wiki-proxy/scp-173"');
+      expect(text).toContain('href="/api/wiki-proxy/scp-682"');
+      expect(text).toContain('href="/api/wiki-proxy/taboo"');
     });
   });
 
   describe("プロキシパス済みリンクは二重変換しない", () => {
-    it("既に /wiki/ プレフィックス付きのリンクは変換しない", async () => {
+    it("既に /wiki/ プレフィックス付きの記事リンクはプロキシ経由に変換される", async () => {
       // Arrange: URL_REWRITE_MAPでフルURLが /wiki/ に変換された後の状態を想定
       const html = `<html><head></head><body><a href="/wiki/scp-456">SCP-456</a></body></html>`;
       global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
@@ -95,9 +95,10 @@ describe("GET /wiki-proxy/*", () => {
       const res = await app.request("/wiki-proxy/scp-173");
       const text = await res.text();
 
-      // Assert: /wiki/wiki/scp-456 にはならない
-      expect(text).toContain('href="/wiki/scp-456"');
+      // Assert: /wiki/ 記事リンクは /api/wiki-proxy/ に変換される
+      expect(text).toContain('href="/api/wiki-proxy/scp-456"');
       expect(text).not.toContain('href="/wiki/wiki/');
+      expect(text).not.toContain('href="/api/wiki-proxy/wiki/');
     });
 
     it("wdfilesプロキシパスは変換しない", async () => {
@@ -128,7 +129,7 @@ describe("GET /wiki-proxy/*", () => {
 
       // Assert: href="/common--theme/..." は書き換え対象外
       expect(text).toContain('href="/common--theme/base.css"');
-      expect(text).not.toContain('href="/wiki/common--theme/');
+      expect(text).not.toContain('href="/api/wiki-proxy/common--theme/');
     });
 
     it("local--filesパスは変換しない", async () => {
@@ -144,12 +145,12 @@ describe("GET /wiki-proxy/*", () => {
 
       // Assert
       expect(text).toContain('href="/local--files/');
-      expect(text).not.toContain('href="/wiki/local--files/');
+      expect(text).not.toContain('href="/api/wiki-proxy/local--files/');
     });
   });
 
-  describe("フルURL書き換え（既存動作）", () => {
-    it("http://scp-jp.wikidot.com/ が /wiki/ に書き換えられる", async () => {
+  describe("フルURL書き換え", () => {
+    it("http://scp-jp.wikidot.com/ のhrefリンクがプロキシ経由に書き換えられる", async () => {
       // Arrange
       const html = `<html><head></head><body><a href="http://scp-jp.wikidot.com/scp-456">SCP-456</a></body></html>`;
       global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
@@ -160,8 +161,24 @@ describe("GET /wiki-proxy/*", () => {
       const res = await app.request("/wiki-proxy/scp-173");
       const text = await res.text();
 
-      // Assert
-      expect(text).toContain('href="/wiki/scp-456"');
+      // Assert: 記事hrefはプロキシ経由に変換される
+      expect(text).toContain('href="/api/wiki-proxy/scp-456"');
+      expect(text).not.toContain("scp-jp.wikidot.com");
+    });
+
+    it("http://scp-jp.wikidot.com/ のリソースリンク（common--/local--）は /wiki/ のまま", async () => {
+      // Arrange
+      const html = `<html><head></head><body><a href="http://scp-jp.wikidot.com/local--files/img.png">img</a></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert: リソースパスはプロキシに変換されない
+      expect(text).toContain('href="/wiki/local--files/img.png"');
       expect(text).not.toContain("scp-jp.wikidot.com");
     });
 
@@ -226,6 +243,41 @@ describe("GET /wiki-proxy/*", () => {
 
       // Assert: 画像がコンテナ幅を超えないようにする
       expect(text).toContain("#page-content img{max-width:100%;height:auto}");
+    });
+  });
+
+  describe("リンクインターセプトJS注入", () => {
+    it("</body>直前にリンクインターセプト用のscriptが注入される", async () => {
+      // Arrange
+      const html = `<html><head></head><body><p>test</p></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain("<script>");
+      expect(text).toContain("addEventListener('click'");
+      expect(text).toContain("/api/wiki-proxy/");
+      expect(text).toContain("</script></body>");
+    });
+
+    it("外部リンクをwindow.openで新しいタブに開くコードが含まれる", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain("window.open(h,'_blank','noopener')");
     });
   });
 

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -77,28 +77,89 @@ const INJECTED_STYLE = [
 const PROXY_PATH_PREFIXES = ["wiki/", "wdfiles-", "wikidot-", "api/", "common--", "local--"];
 
 /**
- * href="/path" 形式の絶対パスリンクを href="/wiki/path" に書き換える正規表現
+ * URL_REWRITE_MAPで /wiki/ に変換されたhrefのうち、記事リンクのみを
+ * /api/wiki-proxy/ に書き換える正規表現
+ *
+ * common--/local-- で始まるリソースパスは除外（Next.js rewritesで処理）
+ */
+const WIKI_ARTICLE_HREF_RE = /href="\/wiki\/(?!common--|local--)/g;
+
+/**
+ * </body>直前に注入するJavaScript
+ *
+ * iframe内のリンククリックをインターセプトし、記事リンクをプロキシ経由で遷移させる。
+ * HTML書き換えで対応できない動的生成リンクの安全策として機能する。
+ *
+ * 処理:
+ * 1. 既にプロキシ済みのリンク → そのまま通過
+ * 2. リソースパス（common--, local--, wdfiles, wikidot） → そのまま通過
+ * 3. /wiki/ 記事リンク → /api/wiki-proxy/ 経由に変換
+ * 4. 外部リンク（http/https） → 新しいタブで開く
+ * 5. その他の絶対パスリンク → /api/wiki-proxy/ 経由に変換
+ */
+const INJECTED_SCRIPT = [
+  "<script>",
+  "document.addEventListener('click',function(e){",
+  "var a=e.target.closest('a[href]');",
+  "if(!a)return;",
+  "var h=a.getAttribute('href');",
+  "if(!h||h.charAt(0)==='#'||h.indexOf('javascript:')===0)return;",
+  "if(h.indexOf('/api/wiki-proxy/')===0)return;",
+  "if(h.indexOf('/common--')===0||h.indexOf('/local--')===0)return;",
+  "if(h.indexOf('/wdfiles')===0||h.indexOf('/wikidot')===0)return;",
+  "if(h.indexOf('/wiki/')===0){",
+  "var p=h.slice(6);",
+  "if(p.indexOf('common--')===0||p.indexOf('local--')===0)return;",
+  "e.preventDefault();",
+  "location.href='/api/wiki-proxy/'+p;",
+  "return}",
+  "if(h.indexOf('http')===0||h.indexOf('//')===0){",
+  "e.preventDefault();",
+  "window.open(h,'_blank','noopener');",
+  "return}",
+  "if(h.charAt(0)==='/'){",
+  "e.preventDefault();",
+  "location.href='/api/wiki-proxy'+h;",
+  "return}",
+  "})",
+  "</script>",
+].join("");
+
+/**
+ * href="/path" 形式の絶対パスリンクを href="/api/wiki-proxy/path" に書き換える正規表現
  *
  * Wiki HTML内のドメインなし絶対パスリンク（例: href="/scp-456"）は
  * URL_REWRITE_MAP では変換されない。
  * そのままだとiframe内で /scp-456 に遷移し、Next.jsの404になるため、
- * /wiki/ プレフィックスを付与して Next.js rewrites 経由でWikiにプロキシする。
+ * /api/wiki-proxy/ 経由に変換して、printer--friendlyモード + CSS注入 + URL書き換えを適用する。
  *
  * 否定先読みで既にプロキシパスに変換済みの href は除外する。
  */
 const ABSOLUTE_PATH_HREF_RE = new RegExp(`href="/(?!${PROXY_PATH_PREFIXES.join("|")})`, "g");
 
 /**
- * HTML書き換え: URL変換 + 不要要素の非表示CSS注入 + 絶対パスリンク修正
+ * HTML書き換え: URL変換 + CSS注入 + 記事リンクのプロキシ化 + リンクインターセプトJS注入
+ *
+ * 処理順序:
+ * 1. CSS注入（</head>前、初回ペイント前に適用）
+ * 2. フルURL書き換え（URL_REWRITE_MAP: http://domain/ → /proxy-path/）
+ * 3. 絶対パスhref書き換え（/scp-456 → /api/wiki-proxy/scp-456）
+ * 4. /wiki/ 記事hrefをプロキシ経由に変換（/wiki/scp-456 → /api/wiki-proxy/scp-456）
+ * 5. リンクインターセプトJS注入（</body>前、動的リンクの安全策）
  */
 function rewriteHtml(html: string): string {
-  // </head> 直前にCSSを注入（初回ペイント前に適用される）
+  // 1. CSS注入
   let result = html.replace("</head>", `${INJECTED_STYLE}</head>`);
+  // 2. フルURL書き換え
   for (const [from, to] of URL_REWRITE_MAP) {
     result = result.replaceAll(from, to);
   }
-  // ドメインなし絶対パスリンクを /wiki/ 経由に書き換え
-  result = result.replace(ABSOLUTE_PATH_HREF_RE, 'href="/wiki/');
+  // 3. ドメインなし絶対パスhrefをプロキシ経由に書き換え
+  result = result.replace(ABSOLUTE_PATH_HREF_RE, 'href="/api/wiki-proxy/');
+  // 4. URL_REWRITE_MAPで /wiki/ に変換された記事hrefをプロキシ経由に変換
+  result = result.replace(WIKI_ARTICLE_HREF_RE, 'href="/api/wiki-proxy/');
+  // 5. リンクインターセプトJS注入
+  result = result.replace("</body>", `${INJECTED_SCRIPT}</body>`);
   return result;
 }
 


### PR DESCRIPTION
## Summary
This PR refactors the wiki-proxy link rewriting logic to route article links through `/api/wiki-proxy/` instead of `/wiki/`, and adds JavaScript-based link interception for dynamic links.

## Key Changes

- **Updated link rewriting strategy**: Changed from `/wiki/` prefix to `/api/wiki-proxy/` for article links, providing better separation of concerns and explicit API routing
  - Absolute path links (`/scp-456`) now rewrite to `/api/wiki-proxy/scp-456`
  - Full URLs (`http://scp-jp.wikidot.com/scp-456`) now rewrite to `/api/wiki-proxy/scp-456`
  - Resource paths (`common--`, `local--`, `wdfiles`, `wikidot`) remain unchanged

- **Added link interception JavaScript**: Injected script before `

https://claude.ai/code/session_01LuKjt3XUS4CEBKVzfW4FQ7