### PR TITLE
Always invoke onContentLoaded callback for fallback handling

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useArticleContent.test.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useArticleContent.test.ts
@@ -103,7 +103,7 @@ describe("useArticleContent", () => {
       });
     });
 
-    it("タイトルまたは本文が空の場合はonContentLoadedを呼ばない", async () => {
+    it("タイトルまたは本文が空の場合でもonContentLoadedが呼ばれる（フォールバック用）", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ title: "", excerpt: "" }),
@@ -120,7 +120,7 @@ describe("useArticleContent", () => {
         await result.current.fetchContent();
       });
 
-      expect(mockOnContentLoaded).not.toHaveBeenCalled();
+      expect(mockOnContentLoaded).toHaveBeenCalledWith({ title: "", excerpt: "" });
     });
   });
 
@@ -144,7 +144,7 @@ describe("useArticleContent", () => {
         })
       ).resolves.not.toThrow();
 
-      expect(mockOnContentLoaded).not.toHaveBeenCalled();
+      expect(mockOnContentLoaded).toHaveBeenCalledWith({ title: "", excerpt: "" });
       expect(consoleErrorSpy).toHaveBeenCalled();
 
       consoleErrorSpy.mockRestore();

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useArticleContent.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useArticleContent.ts
@@ -71,14 +71,14 @@ export function useArticleContent(options: UseArticleContentOptions): UseArticle
       const response = await fetch(`/api/articles/${articleId}/content`);
       const { title, excerpt } = (await response.json()) as ArticleContent;
 
-      // タイトルと本文の両方が存在する場合のみコールバックを呼び出す
-      if (title && excerpt) {
-        onContentLoaded({ title, excerpt });
-      }
+      // 常にコールバックを呼び出す（空データでも呼び出し元でフォールバック処理可能にする）
+      onContentLoaded({ title: title || "", excerpt: excerpt || "" });
     } catch (error) {
       // サイレント失敗: ユーザー体験を妨げない
       // eslint-disable-next-line no-console
       console.error("Content extraction failed:", error);
+      // エラー時も空データでコールバックを呼び出し、履歴保存等のフォールバックを可能にする
+      onContentLoaded({ title: "", excerpt: "" });
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
Changed the article content loading behavior to always invoke the `onContentLoaded` callback, even when the title or excerpt is empty or when an error occurs. This enables callers to implement fallback logic consistently.

## Key Changes
- **Modified callback invocation logic**: Instead of conditionally calling `onContentLoaded` only when both title and excerpt are non-empty, the callback is now always invoked with the fetched data (or empty strings as fallback)
- **Added error handling callback**: When content extraction fails, the callback is now invoked with empty data instead of silently failing, allowing callers to handle errors gracefully
- **Updated test expectations**: Tests now verify that `onContentLoaded` is called with empty data in both empty content and error scenarios, rather than expecting no calls

## Implementation Details
- Empty values are normalized to empty strings (`title || ""`, `excerpt || ""`) before passing to the callback
- Error handling now provides consistent behavior by invoking the callback with empty data, enabling uniform fallback processing in the caller
- This change allows the calling component to decide how to handle empty or failed content loads, rather than having the hook make that decision

https://claude.ai/code/session_01GhkM2YUF9U8RhHZs2CawQL