### PR TITLE
fix(wiki-proxy): 記事コンテンツ領域に左右16pxのパディングを追加

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -224,8 +224,25 @@ describe("GET /wiki-proxy/*", () => {
       const res = await app.request("/wiki-proxy/scp-173");
       const text = await res.text();
 
-      // Assert: 画像がコンテナ幅を超えないようにする
-      expect(text).toContain("#page-content img{max-width:100%;height:auto}");
+      // Assert: 画像がコンテナ幅を超えないようにする + 上下マージン
+      expect(text).toContain(
+        "#page-content img{max-width:100%;height:auto;display:block;margin:16px 0}"
+      );
+    });
+
+    it("コンテンツ領域に左右16pxのパディングが設定される", async () => {
+      // Arrange
+      const html = `<html><head><title>Test</title></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert: モック準拠の左右余白
+      expect(text).toContain("padding:0 16px");
     });
   });
 

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -61,12 +61,12 @@ const INJECTED_STYLE = [
   "#print-options{display:none!important}",
   // 記事可読性: ベースタイポグラフィ
   "body{font-family:'Hiragino Kaku Gothic Pro','ヒラギノ角ゴ Pro W3',Meiryo,sans-serif;line-height:1.8;-webkit-text-size-adjust:100%}",
-  // 記事可読性: コンテンツ領域
-  "#page-content{font-size:15px;overflow-wrap:break-word;word-break:break-word}",
+  // 記事可読性: コンテンツ領域（左右16px余白はモック準拠）
+  "#page-content{font-size:15px;overflow-wrap:break-word;word-break:break-word;padding:0 16px}",
   // 記事可読性: 段落間スペーシング
   "#page-content p{margin-bottom:1em}",
-  // 記事可読性: 画像レスポンシブ化
-  "#page-content img{max-width:100%;height:auto}",
+  // 記事可読性: 画像レスポンシブ化 + 上下マージン
+  "#page-content img{max-width:100%;height:auto;display:block;margin:16px 0}",
   "</style>",
 ].join("");
 


### PR DESCRIPTION
#page-contentにpadding: 0 16pxを追加し、画像やテキストが画面端にくっつく
問題を修正。モックアップ（header-6-minimal-2btn.html）の
.scp-wiki .content { padding: 20px 16px } に準拠。
画像にはdisplay:blockとmargin:16px 0も追加して上下の余白を確保。

https://claude.ai/code/session_01Df15j5ekMo6M1FmCQfwM3m