### PR TITLE
fix(db): feedbackテーブルのCHECK制約にskipタイプを追加

### DIFF
--- a/supabase/migrations/20260208000003_add_skip_to_feedback_type.sql
+++ b/supabase/migrations/20260208000003_add_skip_to_feedback_type.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- feedbackテーブルのtype制約にskipを追加
+-- ============================================
+-- フロントエンド（006-05-06）でskipフィードバックが導入されたが、
+-- DBのCHECK制約が未更新だったため500エラーが発生していた。
+-- 既存制約を削除し、skip を含む新しい制約を作成する。
+-- ============================================
+
+-- 既存のCHECK制約を削除
+ALTER TABLE feedback DROP CONSTRAINT IF EXISTS feedback_type_check;
+
+-- skip を含む新しいCHECK制約を追加
+ALTER TABLE feedback ADD CONSTRAINT feedback_type_check CHECK (type IN ('like', 'dislike', 'skip'));
+
+-- コメント更新
+COMMENT ON COLUMN feedback.type IS 'フィードバックタイプ: like, dislike, skip';


### PR DESCRIPTION
フロントエンドのskipフィードバック機能(006-05-06)導入時に
DBマイグレーションが漏れていたため、type='skip'のINSERT時に
feedback_type_check制約違反で500エラーが発生していた。

https://claude.ai/code/session_012dGVqMxnBxGj9Mz4XmCYqy