### PR TITLE
Simplify ArticleWebView height styling from calc to h-screen

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.test.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.test.tsx
@@ -214,11 +214,11 @@ describe("ArticleWebView", () => {
       expect(iframe).toHaveClass("h-full");
     });
 
-    it("コンテナの高さがcalc(100vh-100px)である", () => {
+    it("コンテナの高さが100vhである", () => {
       const { container } = render(<ArticleWebView url="https://example.com" />);
 
       const root = container.firstChild;
-      expect(root).toHaveClass("h-[calc(100vh-100px)]");
+      expect(root).toHaveClass("h-screen");
     });
   });
 

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
@@ -108,7 +108,7 @@ export function ArticleWebView({
   // サジェスト画面表示（通常のArticleWebViewと同じ高さを維持し、次記事が見えないようにする）
   if (showNotFound) {
     return (
-      <div className={cn("relative w-full h-[calc(100vh-100px)]", className)}>
+      <div className={cn("relative w-full h-screen", className)}>
         <TranslationNotFound onSuggest={handleSuggest} />
       </div>
     );
@@ -118,7 +118,7 @@ export function ArticleWebView({
     <div
       data-testid="article-webview"
       data-url={url}
-      className={cn("relative w-full h-[calc(100vh-100px)]", className)}
+      className={cn("relative w-full h-screen", className)}
     >
       {/* エラー表示 */}
       {error && (


### PR DESCRIPTION
## Summary
Simplified the height styling of the ArticleWebView component by replacing the custom calculated height `calc(100vh-100px)` with the standard Tailwind CSS `h-screen` utility class.

## Changes
- Updated ArticleWebView component to use `h-screen` instead of `h-[calc(100vh-100px)]` for both the main container and the "not found" state container
- Updated corresponding test assertions to verify the new `h-screen` class is applied
- Updated test descriptions to reflect the new height behavior (100vh instead of calc(100vh-100px))

## Implementation Details
This change simplifies the codebase by leveraging Tailwind's built-in `h-screen` utility, which sets height to 100vh. This assumes that the 100px offset previously calculated is no longer needed, or is handled elsewhere in the layout (e.g., through parent container padding/margin or other layout mechanisms).

https://claude.ai/code/session_01Wbgsf1M36Y3eW7hweFmqev