### PR TITLE
Add collapsible-block toggle functionality to wiki-proxy

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -282,6 +282,23 @@ describe("GET /wiki-proxy/*", () => {
       expect(text).toContain("</script></body>");
     });
 
+    it("collapsible-block開閉用のscriptが注入される", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-2000");
+      const text = await res.text();
+
+      // Assert: collapsible-block のトグル処理が含まれる
+      expect(text).toContain("a.collapsible-block-link");
+      expect(text).toContain(".collapsible-block-folded");
+      expect(text).toContain(".collapsible-block-unfolded");
+    });
+
     it("外部リンクをwindow.openで新しいタブに開くコードが含まれる", async () => {
       // Arrange
       const html = `<html><head></head><body></body></html>`;

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -96,6 +96,7 @@ const WIKI_ARTICLE_HREF_RE = /href="\/wiki\/(?!common--|local--)/g;
  * 3. /wiki/ 記事リンク → /api/wiki-proxy/ 経由に変換
  * 4. 外部リンク（http/https） → 新しいタブで開く
  * 5. その他の絶対パスリンク → /api/wiki-proxy/ 経由に変換
+ * 6. collapsible-block の開閉トグル（WIKIDOT.combined.js の代替）
  */
 const INJECTED_SCRIPT = [
   "<script>",
@@ -121,6 +122,26 @@ const INJECTED_SCRIPT = [
   "e.preventDefault();",
   "location.href='/api/wiki-proxy'+h;",
   "return}",
+  "});",
+  // collapsible-block 開閉（WIKIDOT.combined.js の代替）
+  // printer--friendlyモードではWIKIDOT.combined.jsが読み込まれないため、
+  // collapsible-block の開閉をバニラJSで再実装する。
+  "document.addEventListener('click',function(e){",
+  "var l=e.target.closest('a.collapsible-block-link');",
+  "if(!l)return;",
+  "e.preventDefault();",
+  "var b=l.closest('div.collapsible-block');",
+  "if(!b)return;",
+  "var f=b.querySelector('.collapsible-block-folded');",
+  "var u=b.querySelector('.collapsible-block-unfolded');",
+  "if(!f||!u)return;",
+  "if(getComputedStyle(f).display!=='none'){",
+  "f.style.display='none';",
+  "u.style.display='block'",
+  "}else{",
+  "u.style.display='none';",
+  "f.style.display='block'",
+  "}",
   "})",
   "</script>",
 ].join("");


### PR DESCRIPTION
## Summary
Implements collapsible-block open/close toggle functionality in the wiki-proxy route to replace WIKIDOT.combined.js behavior, which is not loaded in printer-friendly mode.

## Changes
- **wiki-proxy.ts**: Added vanilla JavaScript event listener to handle collapsible-block toggling
  - Listens for clicks on `a.collapsible-block-link` elements
  - Toggles visibility between `.collapsible-block-folded` and `.collapsible-block-unfolded` elements
  - Uses `getComputedStyle()` to detect current state and toggle accordingly
  - Injected as part of the HTML response script

- **wiki-proxy.test.ts**: Added test case to verify collapsible-block script injection
  - Validates that the injected script contains required class selectors
  - Ensures toggle functionality is properly included in responses

## Implementation Details
The collapsible-block toggle is implemented as a click event listener that:
1. Targets clicks on collapsible-block-link anchors
2. Finds the parent collapsible-block container
3. Toggles display between folded and unfolded states using inline styles
4. Prevents default link behavior

This provides the same UX as the original WIKIDOT.combined.js without requiring external dependencies.

https://claude.ai/code/session_012qJneLSGzm9fHGHWryY5vu