### PR TITLE
Hide print header in wiki proxy CSS injection

### DIFF
--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -48,7 +48,7 @@ const URL_REWRITE_MAP: readonly (readonly [string, string])[] = [
 /**
  * <head>末尾に注入するCSS
  *
- * 1. printer--friendlyモードの印刷オプションUIを非表示
+ * 1. printer--friendlyモードの印刷オプションUI・印刷ヘッダー（サイト名/ソースURL）を非表示
  * 2. 記事可読性向上（line-height, font-size, spacing）
  *    - モックアップ（header-6-minimal-2btn.html）のスタイルを参考
  *    - 元記事のカラー・装飾は尊重し、可読性に直結するプロパティのみ上書き
@@ -57,8 +57,8 @@ const URL_REWRITE_MAP: readonly (readonly [string, string])[] = [
  */
 const INJECTED_STYLE = [
   "<style>",
-  // 印刷オプション非表示
-  "#print-options{display:none!important}",
+  // 印刷オプション・印刷ヘッダー非表示
+  "#print-options,#print-head{display:none!important}",
   // 記事タイトル: フォントサイズ調整（design-tokens --font-size-3xl: 24px 準拠）
   "#page-title{font-size:24px;font-weight:bold}",
   // 記事可読性: ベースタイポグラフィ


### PR DESCRIPTION
## Summary
Updated the CSS injection in the wiki proxy to hide the print header (site name/source URL) in addition to the existing print options UI when printing in printer-friendly mode.

## Changes
- Modified the CSS selector in `INJECTED_STYLE` to target both `#print-options` and `#print-head` elements
- Updated the corresponding comment to reflect that both the print options UI and print header are now hidden
- Applied `display:none!important` to both selectors to ensure they are hidden during printing

## Details
This change improves the print output by removing redundant header information (site name and source URL) that appears in printer-friendly mode, complementing the existing hiding of the print options UI. The implementation uses a comma-separated CSS selector to apply the same display rule to both elements efficiently.

https://claude.ai/code/session_01RoYV8jVUA9VM1BLpMhbZMf