### PR TITLE
fix(wiki-proxy): reset Wikidot structural element layout to fix artic…

### DIFF
--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -59,6 +59,8 @@ const INJECTED_STYLE = [
   "<style>",
   // 印刷オプション・印刷ヘッダー非表示
   "#print-options,#print-head{display:none!important}",
+  // Wikidot構造要素のレイアウトリセット（#main-contentのmarginで記事幅が狭くなる問題の対処）
+  "#container,#main-content{margin:0;padding:0;max-width:none}",
   // 記事タイトル: フォントサイズ調整（design-tokens --font-size-3xl: 24px 準拠）
   "#page-title{font-size:24px;font-weight:bold}",
   // 記事可読性: ベースタイポグラフィ


### PR DESCRIPTION
…le width

#main-contentのWikidotデフォルトmarginにより記事本文が意図せず狭くなっていた。 #container, #main-contentのmargin/padding/max-widthをリセットし、 #page-contentの左右16px余白のみが効くようにした。

https://claude.ai/code/session_01BRYDQdA9inuNPxdnJ1Viae