### PR TITLE
fix(web): visitorエンドポイントへの重複リクエストを解消

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { VisitorProvider } from "@/shared/contexts/VisitorProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -19,7 +20,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <body className="min-h-screen antialiased">{children}</body>
+      <body className="min-h-screen antialiased">
+        <VisitorProvider>{children}</VisitorProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/shared/contexts/VisitorProvider.tsx
+++ b/apps/web/src/shared/contexts/VisitorProvider.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { createContext, useEffect, useState, useCallback, useRef } from "react";
+import type { ReactNode } from "react";
+import { api } from "../lib/api-client";
+
+/** localStorageキー: visitorId */
+export const VISITOR_ID_KEY = "recommend_scp_visitor_id";
+/** localStorageキー: オンボーディング完了フラグ */
+export const ONBOARDING_COMPLETED_KEY = "recommend_scp_onboarding_completed";
+
+/** VisitorContextの値の型 */
+export interface VisitorContextValue {
+  /** 現在のvisitorId（未初期化時はnull） */
+  visitorId: string | null;
+  /** 初期化中またはAPI呼び出し中 */
+  isLoading: boolean;
+  /** オンボーディング完了済みかどうか */
+  isOnboarded: boolean;
+  /** エラー情報 */
+  error: Error | null;
+  /** visitorIdをリフレッシュ（デバッグ用） */
+  refresh: () => Promise<void>;
+}
+
+/** API レスポンスの型 */
+interface VisitorResponse {
+  visitorId: string;
+  isNew: boolean;
+  createdAt: string;
+  onboardingCompletedAt?: string | null;
+}
+
+export const VisitorContext = createContext<VisitorContextValue | null>(null);
+
+interface VisitorProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * visitorIdを一元管理するProvider
+ *
+ * - localStorageにvisitorIdが存在しない場合、新規UUIDを生成
+ * - APIを1回だけ呼び出してDBと同期
+ * - 子コンポーネントはuseVisitorId()で値を取得
+ */
+export function VisitorProvider({ children }: VisitorProviderProps) {
+  const [visitorId, setVisitorId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isOnboarded, setIsOnboarded] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const isMountedRef = useRef(true);
+
+  const initialize = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // 1. localStorageから取得、または新規UUID生成
+      const storedVisitorId = localStorage.getItem(VISITOR_ID_KEY);
+      const visitorIdToUse = storedVisitorId ?? crypto.randomUUID();
+
+      // 2. APIに登録/同期（既存visitorIdでもAPIを呼んでDBと同期）
+      const res = await api.visitors.$post({
+        json: { visitorId: visitorIdToUse },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
+      if (!res.ok) {
+        throw new Error("Failed to register visitor");
+      }
+
+      const data: VisitorResponse = await res.json();
+
+      // 3. 状態を更新（アンマウント済みの場合はスキップ）
+      if (isMountedRef.current) {
+        localStorage.setItem(VISITOR_ID_KEY, visitorIdToUse);
+
+        if (data.onboardingCompletedAt) {
+          localStorage.setItem(ONBOARDING_COMPLETED_KEY, "true");
+          setIsOnboarded(true);
+        } else {
+          const storedOnboardingCompleted = localStorage.getItem(ONBOARDING_COMPLETED_KEY);
+          setIsOnboarded(storedOnboardingCompleted === "true");
+        }
+
+        setVisitorId(visitorIdToUse);
+      }
+    } catch (e) {
+      if (isMountedRef.current) {
+        setError(e instanceof Error ? e : new Error("Unknown error"));
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    void initialize();
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [initialize]);
+
+  const value: VisitorContextValue = {
+    visitorId,
+    isLoading,
+    isOnboarded,
+    error,
+    refresh: initialize,
+  };
+
+  return <VisitorContext.Provider value={value}>{children}</VisitorContext.Provider>;
+}

--- a/apps/web/src/shared/hooks/useVisitorId.test.ts
+++ b/apps/web/src/shared/hooks/useVisitorId.test.ts
@@ -1,5 +1,7 @@
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ReactNode } from "react";
+import { createElement } from "react";
 
 // モックをテストの前に定義
 vi.mock("../lib/api-client", () => ({
@@ -12,6 +14,7 @@ vi.mock("../lib/api-client", () => ({
 
 // useVisitorIdはモックの後でインポート
 import { useVisitorId, VISITOR_ID_KEY, ONBOARDING_COMPLETED_KEY } from "./useVisitorId";
+import { VisitorProvider } from "../contexts/VisitorProvider";
 import { api } from "../lib/api-client";
 
 const mockApi = api as unknown as {
@@ -19,6 +22,11 @@ const mockApi = api as unknown as {
     $post: ReturnType<typeof vi.fn>;
   };
 };
+
+/** VisitorProviderでラップするヘルパー */
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(VisitorProvider, null, children);
+}
 
 describe("useVisitorId", () => {
   let localStorageStore: Record<string, string>;
@@ -62,7 +70,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -84,7 +92,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -110,7 +118,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -138,7 +146,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -162,7 +170,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -184,7 +192,7 @@ describe("useVisitorId", () => {
       );
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       expect(result.current.isLoading).toBe(true);
@@ -203,7 +211,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       expect(result.current.isLoading).toBe(true);
@@ -223,7 +231,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -241,7 +249,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -255,7 +263,7 @@ describe("useVisitorId", () => {
       mockApi.visitors.$post.mockRejectedValue(new Error("Network Error"));
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -286,7 +294,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -311,7 +319,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -334,7 +342,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -359,7 +367,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -376,7 +384,17 @@ describe("useVisitorId", () => {
       const existingId = "existing-uuid-1234-5678-9abc-def012345678";
       localStorageStore[VISITOR_ID_KEY] = existingId;
 
-      const { result } = renderHook(() => useVisitorId());
+      mockApi.visitors.$post.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            visitorId: existingId,
+            isNew: false,
+            createdAt: "2024-01-01T00:00:00Z",
+          }),
+      });
+
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -409,7 +427,17 @@ describe("useVisitorId", () => {
       const existingId = "existing-uuid-1234-5678-9abc-def012345678";
       localStorageStore[VISITOR_ID_KEY] = existingId;
 
-      const { result } = renderHook(() => useVisitorId());
+      mockApi.visitors.$post.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            visitorId: existingId,
+            isNew: false,
+            createdAt: "2024-01-01T00:00:00Z",
+          }),
+      });
+
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
@@ -463,7 +491,7 @@ describe("useVisitorId", () => {
       );
 
       // Act
-      const { unmount } = renderHook(() => useVisitorId());
+      const { unmount } = renderHook(() => useVisitorId(), { wrapper });
       unmount();
 
       // Promise解決後も警告が出ないことを確認
@@ -492,7 +520,7 @@ describe("useVisitorId", () => {
       });
 
       // Act
-      const { result } = renderHook(() => useVisitorId());
+      const { result } = renderHook(() => useVisitorId(), { wrapper });
 
       // Assert
       await waitFor(() => {
@@ -500,6 +528,13 @@ describe("useVisitorId", () => {
       });
       expect(result.current.error).toBeInstanceOf(Error);
       expect(result.current.error?.message).toBe("localStorage access denied");
+    });
+
+    it("VisitorProvider外で使用するとエラーがスローされる", () => {
+      // Provider無しでrenderHookを実行
+      expect(() => {
+        renderHook(() => useVisitorId());
+      }).toThrow("useVisitorId must be used within a VisitorProvider");
     });
   });
 });

--- a/apps/web/src/shared/hooks/useVisitorId.ts
+++ b/apps/web/src/shared/hooks/useVisitorId.ts
@@ -1,39 +1,21 @@
-import { useEffect, useState, useCallback, useRef } from "react";
-import { api } from "../lib/api-client";
+"use client";
 
-/** localStorageキー: visitorId */
-export const VISITOR_ID_KEY = "recommend_scp_visitor_id";
-/** localStorageキー: オンボーディング完了フラグ */
-export const ONBOARDING_COMPLETED_KEY = "recommend_scp_onboarding_completed";
+import { useContext } from "react";
+import { VisitorContext } from "../contexts/VisitorProvider";
+import type { VisitorContextValue } from "../contexts/VisitorProvider";
+
+// 定数をre-export（既存の利用箇所との後方互換性を維持）
+export { VISITOR_ID_KEY, ONBOARDING_COMPLETED_KEY } from "../contexts/VisitorProvider";
 
 /** useVisitorIdの戻り値の型 */
-export interface UseVisitorIdResult {
-  /** 現在のvisitorId（未初期化時はnull） */
-  visitorId: string | null;
-  /** 初期化中またはAPI呼び出し中 */
-  isLoading: boolean;
-  /** オンボーディング完了済みかどうか */
-  isOnboarded: boolean;
-  /** エラー情報 */
-  error: Error | null;
-  /** visitorIdをリフレッシュ（デバッグ用） */
-  refresh: () => Promise<void>;
-}
-
-/** API レスポンスの型 */
-interface VisitorResponse {
-  visitorId: string;
-  isNew: boolean;
-  createdAt: string;
-  onboardingCompletedAt?: string | null;
-}
+export type UseVisitorIdResult = VisitorContextValue;
 
 /**
- * visitorIdを管理するカスタムフック
+ * visitorIdを取得するカスタムフック
  *
- * - localStorageにvisitorIdが存在しない場合、新規UUIDを生成
- * - 常にAPIを呼び出してDBと同期（visitorが存在しない場合は自動作成）
- * - オンボーディング完了状態も管理
+ * VisitorProvider内で使用すること。
+ * Providerが提供するContextから値を読み取るため、
+ * 複数箇所で呼び出してもAPIリクエストは1回のみ。
  *
  * @example
  * ```tsx
@@ -45,78 +27,11 @@ interface VisitorResponse {
  * ```
  */
 export function useVisitorId(): UseVisitorIdResult {
-  const [visitorId, setVisitorId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isOnboarded, setIsOnboarded] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const context = useContext(VisitorContext);
 
-  // アンマウント検知用
-  const isMountedRef = useRef(true);
+  if (!context) {
+    throw new Error("useVisitorId must be used within a VisitorProvider");
+  }
 
-  const initialize = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // 1. localStorageから取得、または新規UUID生成
-      const storedVisitorId = localStorage.getItem(VISITOR_ID_KEY);
-      const visitorIdToUse = storedVisitorId ?? crypto.randomUUID();
-
-      // 2. APIに登録/同期（既存visitorIdでもAPIを呼んでDBと同期）
-      // これによりDBにvisitorが存在しない場合も自動的に作成される
-      const res = await api.visitors.$post({
-        json: { visitorId: visitorIdToUse },
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
-      if (!res.ok) {
-        throw new Error("Failed to register visitor");
-      }
-
-      const data: VisitorResponse = await res.json();
-
-      // 3. 状態を更新（アンマウント済みの場合はスキップ）
-      if (isMountedRef.current) {
-        // localStorageに保存
-        localStorage.setItem(VISITOR_ID_KEY, visitorIdToUse);
-
-        // サーバーからonboardingCompletedAtが返された場合は同期
-        if (data.onboardingCompletedAt) {
-          localStorage.setItem(ONBOARDING_COMPLETED_KEY, "true");
-          setIsOnboarded(true);
-        } else {
-          // サーバーにonboardingCompletedAtがない場合はlocalStorageも同期
-          const storedOnboardingCompleted = localStorage.getItem(ONBOARDING_COMPLETED_KEY);
-          setIsOnboarded(storedOnboardingCompleted === "true");
-        }
-
-        setVisitorId(visitorIdToUse);
-      }
-    } catch (e) {
-      if (isMountedRef.current) {
-        setError(e instanceof Error ? e : new Error("Unknown error"));
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    void initialize();
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [initialize]);
-
-  return {
-    visitorId,
-    isLoading,
-    isOnboarded,
-    error,
-    refresh: initialize,
-  };
+  return context;
 }


### PR DESCRIPTION
useVisitorIdフックが複数コンポーネントから独立して呼ばれるたびに
POST /visitors APIが実行されていた問題を修正。
VisitorProviderでContextを導入し、APIコールを1回に集約。

https://claude.ai/code/session_01CYomGrAX1GB2rqmJhdKH1R