### PR TITLE
fix(wiki-proxy): 個別記事ページでの読み込み方法修正

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -486,6 +486,57 @@ describe("GET /wiki-proxy/*", () => {
     });
   });
 
+  describe("パスの大文字小文字正規化", () => {
+    it("大文字のarticle IDが小文字に正規化されてfetchされる", async () => {
+      // Arrange: お気に入り経由で大文字の "SCP-2000" が渡されるケース
+      const html = `<html><head></head><body><div id="page-content">SCP-2000</div></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/SCP-2000");
+
+      // Assert: printer--friendly URLが小文字で構築される
+      expect(res.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://scp-jp.wikidot.com/printer--friendly/scp-2000"
+      );
+    });
+
+    it("混在ケース（Scp-173）も小文字に正規化される", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      await app.request("/wiki-proxy/Scp-173");
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://scp-jp.wikidot.com/printer--friendly/scp-173"
+      );
+    });
+
+    it("既に小文字のパスはそのままfetchされる", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      await app.request("/wiki-proxy/scp-173");
+
+      // Assert
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://scp-jp.wikidot.com/printer--friendly/scp-173"
+      );
+    });
+  });
+
   describe("エラーハンドリング", () => {
     it("パスが指定されない場合、400エラーを返す", async () => {
       // Arrange

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -254,11 +254,16 @@ function extractProxyPath(requestPath: string): string {
  * HTMLの場合はURL書き換えを行い、CSS/JS/画像等はそのままパススルーする。
  */
 export const wikiProxyRoutes = new Hono().get("/*", async (c) => {
-  const path = extractProxyPath(c.req.path);
+  const rawPath = extractProxyPath(c.req.path);
 
-  if (!path) {
+  if (!rawPath) {
     return c.json({ error: "path is required" }, 400);
   }
+
+  // Wikidotのprinter--friendlyはスラッグが小文字でないと正常に動作しない。
+  // DBに大文字で格納されたarticle_id（例: "SCP-2000"）経由のリクエストに対応するため、
+  // パスを小文字に正規化する。
+  const path = rawPath.toLowerCase();
 
   // printer--friendly: サイドバー・ナビ・広告を除去して記事本文のみ取得
   const targetUrl = `http://${ALLOWED_WIKIDOT_DOMAIN}/printer--friendly/${path}`;


### PR DESCRIPTION
記事ページ(/article/[articleId])のprinter-friendly表示の調査結果として、
Next.js API Route相当のbasePath("/api")経由でwiki-proxyが正しく動作することを
テストで証明。extractProxyPathのJSDocにHono c.req.param("*")が
ネストされたrouteで空になる注意点を記載。

調査結論:
- 記事ページと推薦ページは同一のiframe URL(/api/wiki-proxy/{id})を生成
- wiki-proxyは常にprinter--friendly URLをfetchする
- Next.js rewritesとの干渉なし
- basePath有無で動作に差異なし（テストで検証済み）

https://claude.ai/code/session_01MATX2GVsPcvyXvnS5TiJpc