### PR TITLE
Fix MenuButton positioning and add padding to wiki page titles

### DIFF
--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -62,7 +62,7 @@ const INJECTED_STYLE = [
   // Wikidot構造要素のレイアウトリセット（#main-contentのmarginで記事幅が狭くなる問題の対処）
   "#container,#main-content{margin:0;padding:0;max-width:none}",
   // 記事タイトル: フォントサイズ調整（design-tokens --font-size-3xl: 24px 準拠）
-  "#page-title{font-size:24px;font-weight:bold}",
+  "#page-title{font-size:24px;font-weight:bold;padding:0 8px}",
   // 記事可読性: ベースタイポグラフィ
   "body{font-family:'Hiragino Kaku Gothic Pro','ヒラギノ角ゴ Pro W3',Meiryo,sans-serif;line-height:1.8;-webkit-text-size-adjust:100%}",
   // 記事可読性: コンテンツ領域（左右16px余白はモック準拠）

--- a/apps/web/src/shared/components/ui/MenuButton/MenuButton.test.tsx
+++ b/apps/web/src/shared/components/ui/MenuButton/MenuButton.test.tsx
@@ -28,13 +28,13 @@ describe("MenuButton", () => {
       expect(svg).toHaveAttribute("role", "img");
     });
 
-    it("fixed配置で左上に固定される", () => {
+    it("fixed配置で右上に固定される", () => {
       renderWithProvider(<MenuButton />);
 
       const button = screen.getByRole("button", { name: /メニューを開く/ });
       expect(button).toHaveClass("fixed");
       expect(button).toHaveClass("top-4");
-      expect(button).toHaveClass("left-4");
+      expect(button).toHaveClass("right-4");
     });
 
     it("z-indexがナビゲーションレベル（z-nav）に設定される", () => {

--- a/apps/web/src/shared/components/ui/MenuButton/MenuButton.tsx
+++ b/apps/web/src/shared/components/ui/MenuButton/MenuButton.tsx
@@ -11,7 +11,7 @@ export const MenuButton = () => {
       type="button"
       onClick={toggle}
       aria-label="メニューを開く"
-      className="fixed top-4 left-4 z-nav w-10 h-10 rounded-full
+      className="fixed top-4 right-4 z-nav w-10 h-10 rounded-full
                  bg-white/80 backdrop-blur-md shadow-sm
                  flex items-center justify-center
                  transition-transform active:scale-95"


### PR DESCRIPTION
## Summary
This PR makes two UI adjustments: repositioning the MenuButton from the left side to the right side of the screen, and adding horizontal padding to wiki article titles for better spacing.

## Key Changes
- **MenuButton positioning**: Changed the fixed position of the MenuButton from `left-4` to `right-4`, moving it from the top-left to the top-right corner of the screen
  - Updated both the component implementation and its corresponding test
- **Wiki page title styling**: Added `padding: 0 8px` to the `#page-title` selector to provide horizontal padding around article titles in the wiki proxy

## Implementation Details
- The MenuButton change affects the layout positioning via Tailwind CSS classes
- The wiki title padding aligns with the design token specifications (8px horizontal padding)
- Test expectations were updated to match the new positioning behavior

https://claude.ai/code/session_01UH4wzDcwC6SzyGJ5xg7muu