### PR TITLE
fix(web): スケルトンUIの高さをh-fullからh-screenに変更

### DIFF
--- a/apps/web/src/shared/components/ui/SkeletonLoader/index.tsx
+++ b/apps/web/src/shared/components/ui/SkeletonLoader/index.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/shared/lib/utils";
  */
 export function SkeletonLoader() {
   return (
-    <div data-testid="skeleton-loader" className="flex h-full w-full flex-col">
+    <div data-testid="skeleton-loader" className="flex h-screen w-full flex-col">
       {/* 記事エリアのスケルトン */}
       <div className="flex-1 animate-pulse bg-gray-100 p-6">
         {/* タイトル */}


### PR DESCRIPTION
親レイアウトの<main>に明示的な高さがないため、h-fullでは
ビューポート全体に広がらなかった。記事ビューアと同じ
h-screenを使用して画面高さと一致させる。

https://claude.ai/code/session_0126iS5LKKpzAF2wcaefo7D1