### PR TITLE
Preserve display:none styles and inject component code viewer CSS

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -446,7 +446,68 @@ describe("GET /wiki-proxy/*", () => {
       // Assert
       expect(text).toContain("<p>赤</p>");
       expect(text).toContain("<span>左</span>");
-      expect(text).not.toContain('style="');
+      expect(text).not.toContain('style="color: red;"');
+      expect(text).not.toContain('style="float: left;"');
+    });
+
+    it("display:noneを含むstyle属性は保持される", async () => {
+      // Arrange: Wikidotコンポーネントの隠し要素パターン
+      const html = `<html><head></head><body><div style="display: none;"><div class="collapsible-block">コード</div></div></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain('style="display: none;"');
+    });
+
+    it("display:none（スペースなし）を含むstyle属性も保持される", async () => {
+      // Arrange
+      const html = `<html><head></head><body><div style="display:none"><span>隠し要素</span></div></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain('style="display:none"');
+    });
+
+    it("display:noneと他のプロパティが混在するstyle属性も保持される", async () => {
+      // Arrange
+      const html = `<html><head></head><body><div style="margin: 0; display: none; color: red;">隠し</div></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain('style="margin: 0; display: none; color: red;"');
+    });
+
+    it("display:block等のnone以外のdisplay値は除去される", async () => {
+      // Arrange
+      const html = `<html><head></head><body><div style="display: block;">表示要素</div></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).not.toContain('style="display: block;"');
     });
 
     it("他の属性は保持される", async () => {
@@ -463,7 +524,26 @@ describe("GET /wiki-proxy/*", () => {
       // Assert
       expect(text).toContain('class="test"');
       expect(text).toContain('id="main"');
-      expect(text).not.toContain('style="');
+      expect(text).not.toContain('style="margin: 0;"');
+    });
+  });
+
+  describe("コンポーネントコードビューア非表示CSS", () => {
+    it("コンポーネントコードビューアを非表示にするCSSが注入される", async () => {
+      // Arrange
+      const html = `<html><head><title>Test</title></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-173");
+      const text = await res.text();
+
+      // Assert
+      expect(text).toContain(
+        ".collapsible-block:has(>.collapsible-block-unfolded>.collapsible-block-content>.code){display:none!important}"
+      );
     });
   });
 

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -73,6 +73,9 @@ const INJECTED_STYLE = [
   "#page-content img{max-width:100%;height:auto;display:block;margin:16px 0}",
   // レイアウト崩れ防止: Wikidot記事のfloatブロックを無効化
   "#page-content .block-left,#page-content .block-right{float:none!important;clear:both!important;text-align:left!important;margin:0 auto!important}",
+  // コンポーネントコードビューア非表示: テーマ等のコンポーネントincludeに付随する
+  // CSSソースコード表示用collapsible-blockを非表示にする（記事本文ではない）
+  ".collapsible-block:has(>.collapsible-block-unfolded>.collapsible-block-content>.code){display:none!important}",
   "</style>",
 ].join("");
 
@@ -159,10 +162,15 @@ const INJECTED_SCRIPT = [
  * モバイル表示でレイアウト崩れを起こす。記事の装飾はInjected CSSで制御するため、
  * インラインstyle属性は安全に除去できる。
  *
+ * ただし `display: none` を含むstyle属性は保持する。
+ * Wikidotのコンポーネント（テーマCSS等）は親divの `style="display: none;"` で
+ * コード表示ブロックを隠しており、除去すると本来非表示のUIが表示されてしまう。
+ *
  * - `style="..."` （ダブルクォート）を対象
  * - 属性前の空白ごと除去してHTML構造を保持
+ * - 否定先読みで `display: none` / `display:none` を含む属性をスキップ
  */
-const INLINE_STYLE_ATTR_RE = / style="[^"]*"/gi;
+const INLINE_STYLE_ATTR_RE = / style="(?![^"]*display\s*:\s*none)[^"]*"/gi;
 
 /**
  * href="/path" 形式の絶対パスリンクを href="/api/wiki-proxy/path" に書き換える正規表現


### PR DESCRIPTION
## Summary
This PR improves the wiki-proxy route's style attribute handling to preserve `display: none` styles while removing other inline styles, and injects CSS to hide component code viewer blocks.

## Key Changes
- **Updated inline style attribute regex** to preserve `display: none` declarations while removing other inline styles
  - Changed regex from `/ style="[^"]*"/gi` to `/ style="(?![^"]*display\s*:\s*none)[^"]*"/gi`
  - Uses negative lookahead to skip style attributes containing `display: none` (with or without spaces)
  - This prevents breaking Wikidot component layouts that rely on `display: none` to hide code blocks

- **Injected new CSS rule** to hide component code viewer blocks
  - Added `.collapsible-block:has(>.collapsible-block-unfolded>.collapsible-block-content>.code){display:none!important}`
  - Targets collapsible blocks that contain code elements (typically from theme/component includes)
  - Prevents CSS source code from being displayed in article content

- **Expanded test coverage** with 5 new test cases:
  - Verify `display: none` with spaces is preserved
  - Verify `display:none` without spaces is preserved
  - Verify mixed properties with `display: none` are preserved
  - Verify non-none display values (e.g., `display: block`) are removed
  - Verify component code viewer CSS is injected

## Implementation Details
The regex uses a negative lookahead assertion to conditionally match style attributes. It will skip (not match) any style attribute containing the pattern `display\s*:\s*none`, allowing those attributes to be preserved while removing all others. This approach handles both spacing variations (`display: none` and `display:none`).

https://claude.ai/code/session_012Ame6PDfEHywzjgrsFZGRr