### PR TITLE
fix(wiki-proxy): colmod折りたたみとYUIタブビューの開閉をサポート

### DIFF
--- a/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
+++ b/apps/api-server/src/routes/__dev__/wiki-proxy.test.ts
@@ -413,6 +413,42 @@ describe("GET /wiki-proxy/*", () => {
       // Assert
       expect(text).toContain("window.open(h,'_blank','noopener')");
     });
+
+    it("colmod（coltop/colend）開閉用のscriptが注入される", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-7992");
+      const text = await res.text();
+
+      // Assert: colmod のトグル処理が含まれる
+      expect(text).toContain(".colmod-link-top a");
+      expect(text).toContain(".colmod-link-end a");
+      expect(text).toContain("classList.replace('folded','unfolded')");
+      expect(text).toContain("classList.replace('unfolded','folded')");
+    });
+
+    it("YUI TabView切り替え用のscriptが注入される", async () => {
+      // Arrange
+      const html = `<html><head></head><body></body></html>`;
+      global.fetch = vi.fn().mockResolvedValue(createHtmlResponse(html));
+
+      const app = createApp();
+
+      // Act
+      const res = await app.request("/wiki-proxy/scp-7992");
+      const text = await res.text();
+
+      // Assert: YUI TabView のタブ切り替え処理が含まれる
+      expect(text).toContain(".yui-nav a");
+      expect(text).toContain(".yui-navset");
+      expect(text).toContain(".yui-content>div");
+      expect(text).toContain("classList.add('selected')");
+    });
   });
 
   describe("インラインstyle属性の除去", () => {

--- a/apps/api-server/src/routes/wiki-proxy.ts
+++ b/apps/api-server/src/routes/wiki-proxy.ts
@@ -106,6 +106,8 @@ const WIKI_ARTICLE_HREF_RE = /href="\/wiki\/(?!common--|local--)/g;
  * 4. 外部リンク（http/https） → 新しいタブで開く
  * 5. その他の絶対パスリンク → /api/wiki-proxy/ 経由に変換
  * 6. collapsible-block の開閉トグル（WIKIDOT.combined.js の代替）
+ * 7. colmod（coltop/colend）ネスト可能折りたたみの開閉トグル
+ * 8. YUI TabView のタブ切り替え
  */
 const INJECTED_SCRIPT = [
   "<script>",
@@ -151,6 +153,42 @@ const INJECTED_SCRIPT = [
   "u.style.display='none';",
   "f.style.display='block'",
   "}",
+  "});",
+  // colmod（coltop/colend）開閉（WIKIDOT.combined.js の代替）
+  // Boyu12氏がSCP-JP向けに開発したネスト可能折りたたみコンポーネント。
+  // 標準の[[collapsible]]とは異なるHTML構造を使用:
+  //   .colmod-block > ul > li.folded/.unfolded > .colmod-link-top > a
+  // li要素のクラスを folded ↔ unfolded で切り替えることで開閉する。
+  "document.addEventListener('click',function(e){",
+  "var a=e.target.closest('.colmod-link-top a,.colmod-link-end a');",
+  "if(!a)return;",
+  "e.preventDefault();",
+  "var li=a.closest('li');",
+  "if(!li)return;",
+  "if(li.classList.contains('folded')){",
+  "li.classList.replace('folded','unfolded')",
+  "}else if(li.classList.contains('unfolded')){",
+  "li.classList.replace('unfolded','folded')",
+  "}",
+  "});",
+  // YUI TabView タブ切り替え（WIKIDOT.combined.js の代替）
+  // Wikidotの[[tabview]]構文が生成するYUI TabViewウィジェットのタブ切り替えを
+  // バニラJSで再実装する。.yui-nav内のタブクリックで.yui-content内のパネルを切り替え。
+  "document.addEventListener('click',function(e){",
+  "var a=e.target.closest('.yui-nav a');",
+  "if(!a)return;",
+  "e.preventDefault();",
+  "var ns=a.closest('.yui-navset');",
+  "if(!ns)return;",
+  "var li=a.closest('li');",
+  "if(!li)return;",
+  "var tabs=ns.querySelectorAll('.yui-nav>li');",
+  "var idx=Array.prototype.indexOf.call(tabs,li);",
+  "if(idx<0)return;",
+  "tabs.forEach(function(t){t.classList.remove('selected')});",
+  "li.classList.add('selected');",
+  "var panels=ns.querySelectorAll('.yui-content>div');",
+  "panels.forEach(function(p,i){p.style.display=i===idx?'block':'none'})",
   "})",
   "</script>",
 ].join("");


### PR DESCRIPTION
printer--friendlyモードで動作しないWikidotインタラクティブ要素に対応:

- colmod (coltop/colend): SCP-JP向けネスト可能折りたたみコンポーネント
  li.folded/li.unfoldedのクラス切り替えで開閉を制御
- YUI TabView: [[tabview]]構文が生成するタブ切り替えウィジェット
  .yui-nav内のタブクリックで.yui-content内パネルを切り替え

SCP-7992等のcolmodを使用する記事で折りたたみ要素が反応しない問題を修正

https://claude.ai/code/session_011VrfWD5SERRZpr21gtfjs5