### PR TITLE
Wrap Supabase PostgrestError in DatabaseError for proper error handling

### DIFF
--- a/apps/api-server/src/app.ts
+++ b/apps/api-server/src/app.ts
@@ -13,6 +13,7 @@ import { Hono } from "hono";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { corsMiddleware } from "./middleware/cors";
 import { errorHandler } from "./middleware/error-handler";
+import { DatabaseError } from "./lib/errors";
 import { healthRoutes } from "./routes/health";
 import { checkUrlRoutes } from "./routes/check-url";
 import { wikiProxyRoutes } from "./routes/wiki-proxy";
@@ -73,6 +74,27 @@ export const createApp = (supabase: SupabaseClient) => {
   const app = new Hono()
     // CORSミドルウェア（全ルートに適用）
     .use(corsMiddleware)
+    // Supabase PostgrestError等の非Errorオブジェクトをラップするミドルウェア
+    //
+    // Supabase PostgREST のエラーは Error を継承しないプレーンオブジェクト
+    // ({ message, details, hint, code }) として返される。
+    // Hono の onError ハンドラは Error インスタンスのみキャッチするため、
+    // そのまま throw すると onError をすり抜けて 500 になる。
+    // このミドルウェアで非Error を DatabaseError にラップし、
+    // onError で適切にハンドリングできるようにする。
+    .use(async (_, next) => {
+      try {
+        await next();
+      } catch (err) {
+        if (err instanceof Error) throw err;
+        if (typeof err === "object" && err !== null && "message" in err) {
+          throw new DatabaseError(
+            err as { message: string; details?: string; hint?: string; code?: string }
+          );
+        }
+        throw new Error(String(err));
+      }
+    })
     // RFC 7807 Problem Details形式のエラーハンドリング
     .onError(errorHandler)
     // ルートをマウント

--- a/apps/api-server/src/domains/articles/__dev__/repository.test.ts
+++ b/apps/api-server/src/domains/articles/__dev__/repository.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ArticlesRepository } from "../repository";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { DatabaseError } from "../../../lib/errors";
 
 describe("ArticlesRepository", () => {
   let repository: ArticlesRepository;
@@ -90,7 +91,7 @@ describe("ArticlesRepository", () => {
       const mockError = { code: "ERROR", message: "RPC function not found" };
       mockSupabase.rpc.mockResolvedValue({ data: null, error: mockError });
 
-      await expect(repository.searchByEmbedding([0.1, 0.2])).rejects.toEqual(mockError);
+      await expect(repository.searchByEmbedding([0.1, 0.2])).rejects.toBeInstanceOf(DatabaseError);
     });
   });
 
@@ -160,7 +161,7 @@ describe("ArticlesRepository", () => {
       };
       mockSupabase.from.mockReturnValue(mockChain);
 
-      await expect(repository.getArticleById("test")).rejects.toEqual(mockError);
+      await expect(repository.getArticleById("test")).rejects.toBeInstanceOf(DatabaseError);
     });
   });
 });

--- a/apps/api-server/src/domains/articles/repository.ts
+++ b/apps/api-server/src/domains/articles/repository.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { VectorSearchClientResult } from "@recommend-scp/shared/search";
+import { DatabaseError } from "../../lib/errors";
 
 /**
  * Supabaseエラー型
@@ -88,7 +89,7 @@ export class ArticlesRepository {
       match_count: options.limit ?? 10,
     })) as unknown as SupabaseResponse<VectorSearchClientResult[]>;
 
-    if (response.error !== null) throw response.error;
+    if (response.error !== null) throw new DatabaseError(response.error);
     return response.data ?? [];
   };
 
@@ -107,7 +108,7 @@ export class ArticlesRepository {
 
     // PGRST116: 行が見つからない場合のエラーコード
     if (response.error?.code === "PGRST116") return null;
-    if (response.error !== null) throw response.error;
+    if (response.error !== null) throw new DatabaseError(response.error);
     return response.data;
   };
 
@@ -137,7 +138,7 @@ export class ArticlesRepository {
 
     // PGRST116: 行が見つからない場合のエラーコード
     if (response.error?.code === "PGRST116") return null;
-    if (response.error !== null) throw response.error;
+    if (response.error !== null) throw new DatabaseError(response.error);
     return response.data;
   };
 }

--- a/apps/api-server/src/domains/favorites/__dev__/repository.test.ts
+++ b/apps/api-server/src/domains/favorites/__dev__/repository.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { FavoritesRepository } from "../repository";
 import type { FavoriteWithArticle } from "../types";
+import { DatabaseError } from "../../../lib/errors";
 
 /** DB行の型（JOIN後のsnake_case） */
 interface MockFavoriteRow {
@@ -152,10 +153,7 @@ describe("FavoritesRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.getByVisitorId("visitor-1")).rejects.toEqual({
-        code: "PGRST500",
-        message: "DB Error",
-      });
+      await expect(repository.getByVisitorId("visitor-1")).rejects.toBeInstanceOf(DatabaseError);
     });
 
     describe("ObjectClass抽出", () => {
@@ -407,10 +405,9 @@ describe("FavoritesRepository", () => {
         });
 
       // Act & Assert
-      await expect(repository.add("visitor-1", "SCP-INVALID")).rejects.toEqual({
-        code: "23503",
-        message: "Foreign key violation",
-      });
+      await expect(repository.add("visitor-1", "SCP-INVALID")).rejects.toBeInstanceOf(
+        DatabaseError
+      );
     });
   });
 
@@ -497,10 +494,7 @@ describe("FavoritesRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.remove("visitor-1", "SCP-173")).rejects.toEqual({
-        code: "PGRST500",
-        message: "DB Error",
-      });
+      await expect(repository.remove("visitor-1", "SCP-173")).rejects.toBeInstanceOf(DatabaseError);
     });
   });
 });

--- a/apps/api-server/src/domains/favorites/repository.ts
+++ b/apps/api-server/src/domains/favorites/repository.ts
@@ -7,6 +7,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { FavoriteWithArticle, AddFavoriteResult } from "./types";
 import { OBJECT_CLASSES } from "./types";
+import { DatabaseError } from "../../lib/errors";
 
 /** DB行の型（JOIN後のsnake_case） */
 interface FavoriteRow {
@@ -68,7 +69,7 @@ export class FavoritesRepository {
       .eq("visitor_id", visitorId)
       .order("added_at", { ascending: false });
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return (data as unknown as FavoriteRow[]).map((row) => this.toFavoriteWithArticle(row));
   };
@@ -87,7 +88,7 @@ export class FavoritesRepository {
       .eq("visitor_id", visitorId)
       .eq("article_id", articleId.toLowerCase());
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return (count ?? 0) > 0;
   };
@@ -108,7 +109,7 @@ export class FavoritesRepository {
       .eq("article_id", articleId.toLowerCase())
       .maybeSingle();
 
-    if (selectError) throw selectError;
+    if (selectError) throw new DatabaseError(selectError);
 
     if (existing) {
       return {
@@ -126,7 +127,7 @@ export class FavoritesRepository {
       .select("id, article_id, added_at")
       .single();
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return {
       id: data.id as string,

--- a/apps/api-server/src/domains/feedback/__dev__/repository.test.ts
+++ b/apps/api-server/src/domains/feedback/__dev__/repository.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Feedback } from "@recommend-scp/shared/storage/server";
 import { FeedbackRepository } from "../repository";
+import { DatabaseError } from "../../../lib/errors";
 
 /** モック用DB行の型 */
 interface MockFeedbackRow {
@@ -131,7 +132,7 @@ describe("FeedbackRepository", () => {
           type: "like",
           createdAt: "2025-01-20T10:00:00Z",
         })
-      ).rejects.toEqual({ code: "PGRST500", message: "DB Error" });
+      ).rejects.toBeInstanceOf(DatabaseError);
     });
   });
 
@@ -183,10 +184,7 @@ describe("FeedbackRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.getByVisitorId("visitor-1")).rejects.toEqual({
-        code: "PGRST500",
-        message: "DB Error",
-      });
+      await expect(repository.getByVisitorId("visitor-1")).rejects.toBeInstanceOf(DatabaseError);
     });
   });
 });

--- a/apps/api-server/src/domains/feedback/repository.ts
+++ b/apps/api-server/src/domains/feedback/repository.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Feedback } from "@recommend-scp/shared/storage/server";
+import { DatabaseError } from "../../lib/errors";
 
 /** DB行の型（snake_case） */
 interface FeedbackRow {
@@ -50,7 +51,7 @@ export class FeedbackRepository {
       .select("id, visitor_id, article_id, type, created_at")
       .single();
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return this.toFeedback(data as unknown as FeedbackRow);
   };
@@ -67,7 +68,7 @@ export class FeedbackRepository {
       .select("id, visitor_id, article_id, type, created_at")
       .eq("visitor_id", visitorId);
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return (data as unknown as FeedbackRow[]).map(this.toFeedback);
   };

--- a/apps/api-server/src/domains/visitors/__dev__/repository.test.ts
+++ b/apps/api-server/src/domains/visitors/__dev__/repository.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { VisitorsRepository } from "../repository";
+import { DatabaseError } from "../../../lib/errors";
 
 // Supabaseクエリビルダーのモック作成ヘルパー
 const createQueryMock = (result: { data: unknown; error: unknown }) => ({
@@ -82,9 +83,10 @@ describe("VisitorsRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.findByVisitorId("test")).rejects.toEqual({
+      await expect(repository.findByVisitorId("test")).rejects.toBeInstanceOf(DatabaseError);
+      await expect(repository.findByVisitorId("test")).rejects.toMatchObject({
         code: "PGRST500",
-        message: "DB Error",
+        detail: "DB Error",
       });
     });
   });
@@ -116,9 +118,10 @@ describe("VisitorsRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.create("existing-visitor")).rejects.toEqual({
+      await expect(repository.create("existing-visitor")).rejects.toBeInstanceOf(DatabaseError);
+      await expect(repository.create("existing-visitor")).rejects.toMatchObject({
         code: "23505",
-        message: "UNIQUE constraint violation",
+        detail: "UNIQUE constraint violation",
       });
     });
   });
@@ -159,9 +162,10 @@ describe("VisitorsRepository", () => {
       });
       mockFrom.mockReturnValue(queryMock);
 
-      await expect(repository.existsByVisitorId("test")).rejects.toEqual({
+      await expect(repository.existsByVisitorId("test")).rejects.toBeInstanceOf(DatabaseError);
+      await expect(repository.existsByVisitorId("test")).rejects.toMatchObject({
         code: "PGRST500",
-        message: "DB Error",
+        detail: "DB Error",
       });
     });
   });

--- a/apps/api-server/src/domains/visitors/repository.ts
+++ b/apps/api-server/src/domains/visitors/repository.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Visitor } from "./types";
+import { DatabaseError } from "../../lib/errors";
 
 /** DB行の型（snake_case） */
 interface VisitorRow {
@@ -39,7 +40,7 @@ export class VisitorsRepository {
 
     // Not found (PGRST116)
     if (error?.code === "PGRST116") return null;
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return this.toVisitor(data as VisitorRow);
   };
@@ -58,7 +59,7 @@ export class VisitorsRepository {
       .select("id, visitor_id, created_at, updated_at")
       .single();
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return this.toVisitor(data as VisitorRow);
   };
@@ -75,7 +76,7 @@ export class VisitorsRepository {
       .select("*", { count: "exact", head: true })
       .eq("visitor_id", visitorId);
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
 
     return (count ?? 0) > 0;
   };

--- a/apps/api-server/src/lib/errors.ts
+++ b/apps/api-server/src/lib/errors.ts
@@ -69,3 +69,38 @@ export class OnboardingRequiredError extends AppError {
     );
   }
 }
+
+/**
+ * Supabase PostgrestError のインターフェース
+ *
+ * Supabase の PostgREST エラーは Error クラスを継承しておらず、
+ * プレーンオブジェクトとして返される。Hono の onError ハンドラは
+ * Error インスタンスのみをキャッチするため、そのまま throw すると
+ * エラーハンドラをすり抜けて 500 になる。
+ */
+interface PostgrestErrorLike {
+  message: string;
+  details?: string;
+  hint?: string;
+  code?: string;
+}
+
+/**
+ * データベースエラー
+ *
+ * Supabase PostgREST のエラーオブジェクト（プレーンオブジェクト）を
+ * Error インスタンスにラップし、Hono の onError ハンドラで
+ * キャッチ可能にする。
+ *
+ * @example
+ * const { data, error } = await supabase.from("visitors").select("*");
+ * if (error) throw new DatabaseError(error);
+ */
+export class DatabaseError extends AppError {
+  readonly code: string;
+
+  constructor(supabaseError: PostgrestErrorLike) {
+    super(`${BASE_URI}/internal-error`, "Database Error", 500, supabaseError.message);
+    this.code = supabaseError.code ?? "";
+  }
+}

--- a/apps/api-server/src/lib/storage/supabase-preference-storage.ts
+++ b/apps/api-server/src/lib/storage/supabase-preference-storage.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { logger } from "../logger";
+import { DatabaseError } from "../errors";
 import { parseVectorField } from "./parse-vector";
 import type {
   PreferenceStorage,
@@ -51,7 +52,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       .from("visitors")
       .upsert(this.toVisitorRow(profile), { onConflict: "visitor_id" });
 
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -69,7 +70,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
     }
 
     const result = await query;
-    if (result.error) throw result.error;
+    if (result.error) throw new DatabaseError(result.error);
     const rows = (result.data as DbRow[] | null) ?? [];
     return rows.map(this.toViewHistory);
   };
@@ -84,7 +85,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       viewed_at: history.viewedAt,
       duration: history.duration,
     });
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -93,7 +94,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
   getFeedback = async (visitorId: string): Promise<Feedback[]> => {
     const result = await this.supabase.from("feedback").select("*").eq("visitor_id", visitorId);
 
-    if (result.error) throw result.error;
+    if (result.error) throw new DatabaseError(result.error);
     const rows = (result.data as DbRow[] | null) ?? [];
     return rows.map(this.toFeedback);
   };
@@ -126,7 +127,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       },
       { onConflict: "visitor_id,article_id" }
     );
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -147,7 +148,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
     }
 
     const result = await query;
-    if (result.error) throw result.error;
+    if (result.error) throw new DatabaseError(result.error);
     const rows = (result.data as DbRow[] | null) ?? [];
     return rows.map(this.toRecommendationLog);
   };
@@ -163,7 +164,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       recommended_at: log.recommendedAt,
       clicked: log.clicked,
     });
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -176,7 +177,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       .eq("visitor_id", visitorId)
       .eq("type", "dislike");
 
-    if (result.error) throw result.error;
+    if (result.error) throw new DatabaseError(result.error);
     const rows = (result.data as DbRow[] | null) ?? [];
     return rows.map((d) => d.article_id as string);
   };
@@ -208,7 +209,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       .eq("visitor_id", visitorId)
       .order("added_at", { ascending: false });
 
-    if (result.error) throw result.error;
+    if (result.error) throw new DatabaseError(result.error);
     const rows = (result.data as DbRow[] | null) ?? [];
     return rows.map(this.toFavorite);
   };
@@ -225,7 +226,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       },
       { onConflict: "visitor_id,article_id" }
     );
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -237,7 +238,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       .delete()
       .eq("visitor_id", visitorId)
       .eq("article_id", articleId);
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -245,7 +246,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
    */
   clearViewHistory = async (visitorId: string): Promise<void> => {
     const { error } = await this.supabase.from("view_history").delete().eq("visitor_id", visitorId);
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -256,7 +257,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
       .from("recommendation_log")
       .delete()
       .eq("visitor_id", visitorId);
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   /**
@@ -264,7 +265,7 @@ export class SupabasePreferenceStorage implements PreferenceStorage {
    */
   clearFeedback = async (visitorId: string): Promise<void> => {
     const { error } = await this.supabase.from("feedback").delete().eq("visitor_id", visitorId);
-    if (error) throw error;
+    if (error) throw new DatabaseError(error);
   };
 
   // ============================================

--- a/apps/api-server/src/lib/storage/supabase-vector-search.ts
+++ b/apps/api-server/src/lib/storage/supabase-vector-search.ts
@@ -11,6 +11,7 @@ import type {
   VectorSearchClientResult,
   UnexploredTagsSearchParams,
 } from "@recommend-scp/shared/search";
+import { DatabaseError } from "../errors";
 import { parseVectorField } from "./parse-vector";
 
 /**
@@ -96,7 +97,7 @@ export class SupabaseVectorSearch implements VectorSearchClient {
     )) as unknown as SupabaseResponse<SearchResultRow[]>;
 
     if (response.error !== null) {
-      throw response.error;
+      throw new DatabaseError(response.error);
     }
 
     const rows = response.data ?? [];
@@ -160,7 +161,7 @@ export class SupabaseVectorSearch implements VectorSearchClient {
     )) as unknown as SupabaseResponse<SearchResultRow[]>;
 
     if (response.error !== null) {
-      throw response.error;
+      throw new DatabaseError(response.error);
     }
 
     const rows = response.data ?? [];


### PR DESCRIPTION
## Summary
This PR introduces a new `DatabaseError` class to wrap Supabase PostgREST errors, ensuring they are properly caught by Hono's error handler middleware. Supabase errors are plain objects that don't inherit from `Error`, causing them to bypass the error handler and result in unhandled 500 responses.

## Key Changes

- **New `DatabaseError` class** (`apps/api-server/src/lib/errors.ts`):
  - Extends `AppError` to wrap Supabase `PostgrestErrorLike` objects
  - Preserves error code and message from the original error
  - Returns HTTP 500 status with proper error details

- **Error wrapping middleware** (`apps/api-server/src/app.ts`):
  - Added middleware to catch non-Error objects thrown during request processing
  - Automatically wraps plain objects with `message` property in `DatabaseError`
  - Ensures all errors are `Error` instances before reaching the error handler

- **Updated all database operations** to throw `DatabaseError`:
  - `SupabasePreferenceStorage`: 13 error handling sites
  - `SupabaseVectorSearch`: 2 error handling sites
  - `FavoritesRepository`: 4 error handling sites
  - `VisitorsRepository`: 3 error handling sites
  - `FeedbackRepository`: 2 error handling sites
  - `ArticlesRepository`: 3 error handling sites

- **Updated test assertions**:
  - Changed from expecting plain error objects to expecting `DatabaseError` instances
  - Updated error property assertions to match `DatabaseError` structure (e.g., `detail` instead of `message`)

## Implementation Details

The solution uses a two-layer approach:
1. **Explicit wrapping**: All database operations explicitly wrap Supabase errors in `DatabaseError`
2. **Fallback middleware**: A catch-all middleware provides defense-in-depth for any missed cases

This ensures that Hono's `onError` handler can properly catch and format all database errors according to RFC 7807 Problem Details specification.

https://claude.ai/code/session_01QyiE2ZAD57y6feA1AsrGnQ