### PR TITLE
fix(recommend): スプラッシュカードをiframe読み込み完了まで表示し続けるよう修正

### DIFF
--- a/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
@@ -59,6 +59,7 @@ const mockUseIframePoolResult = {
     { articleIndex: number; url: string; isLoaded: boolean } | null,
   ],
   advance: vi.fn(),
+  handleIframeLoad: vi.fn(),
 };
 
 // ─── モック定義 ───
@@ -147,8 +148,8 @@ vi.mock("../_components/ArticleWebView", () => ({
     onIframeLoad?: () => void;
     className?: string;
   }) => {
-    // Current スロット（hidden以外）のonIframeLoadをキャプチャ
-    if (onIframeLoad && !className?.includes("hidden")) {
+    // Current スロット（pointer-events-none以外）のonIframeLoadをキャプチャ
+    if (onIframeLoad && !className?.includes("pointer-events-none")) {
       capturedOnIframeLoad = onIframeLoad;
     }
     return (
@@ -325,7 +326,7 @@ describe("RecommendPage 統合テスト (006-05-07)", () => {
       dismissInitialCard();
 
       const webviews = screen.getAllByTestId("article-webview");
-      expect(webviews[0]).toHaveClass("opacity-100");
+      expect(webviews[0]).toHaveClass("opacity-100", "z-10");
     });
   });
 
@@ -415,18 +416,18 @@ describe("RecommendPage 統合テスト (006-05-07)", () => {
         capturedOnDismissed?.();
       });
 
-      // iframe読み込み完了前は非表示（opacity-0）
+      // iframe読み込み完了前は非表示（opacity-0 z-10）
       const webviews = screen.getAllByTestId("article-webview");
       const currentSlot = webviews[0];
-      expect(currentSlot).toHaveClass("opacity-0");
+      expect(currentSlot).toHaveClass("opacity-0", "z-10");
 
       // iframe読み込み完了を通知
       act(() => {
         capturedOnIframeLoad?.();
       });
 
-      // 読み込み完了後は表示（opacity-100）
-      expect(currentSlot).toHaveClass("opacity-100");
+      // 読み込み完了後は表示（opacity-100 z-10）
+      expect(currentSlot).toHaveClass("opacity-100", "z-10");
     });
 
     it("遷移完了後にcurrentIndexが更新される（goToNext呼び出し確認）", async () => {

--- a/apps/web/src/app/(main)/recommend/_components/TransitionCard/__tests__/TransitionCard.test.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/TransitionCard/__tests__/TransitionCard.test.tsx
@@ -142,16 +142,36 @@ describe("TransitionCard", () => {
   });
 
   // ===========================================
-  // AC-5: 適応型タイミング（最大表示時間）
+  // AC-5: iframe読み込み完了まで表示し続ける
   // ===========================================
-  describe("AC-5: 適応型タイミング（最大表示時間）", () => {
-    it("1000ms経過でiframe未完了でも強制的にフェードアウトする", () => {
+  describe("AC-5: iframe読み込み完了まで表示し続ける", () => {
+    it("1000ms経過でもiframe未完了なら表示し続ける", () => {
       const onDismissed = vi.fn();
       render(<TransitionCard {...defaultProps} isContentReady={false} onDismissed={onDismissed} />);
 
       // 1000ms経過
       act(() => {
         vi.advanceTimersByTime(1000);
+      });
+
+      // フェードアウトしない
+      expect(onDismissed).not.toHaveBeenCalled();
+
+      // 3000ms経過してもiframe未完了なら表示し続ける
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(onDismissed).not.toHaveBeenCalled();
+    });
+
+    it("安全弁タイムアウト（15秒）で強制フェードアウトする", () => {
+      const onDismissed = vi.fn();
+      render(<TransitionCard {...defaultProps} isContentReady={false} onDismissed={onDismissed} />);
+
+      // 15000ms経過
+      act(() => {
+        vi.advanceTimersByTime(15000);
       });
 
       // フェードアウト完了（150ms）
@@ -162,12 +182,12 @@ describe("TransitionCard", () => {
       expect(onDismissed).toHaveBeenCalledTimes(1);
     });
 
-    it("999ms時点では強制フェードアウトしない", () => {
+    it("14999ms時点では強制フェードアウトしない", () => {
       const onDismissed = vi.fn();
       render(<TransitionCard {...defaultProps} isContentReady={false} onDismissed={onDismissed} />);
 
       act(() => {
-        vi.advanceTimersByTime(999);
+        vi.advanceTimersByTime(14999);
       });
 
       expect(onDismissed).not.toHaveBeenCalled();

--- a/apps/web/src/app/(main)/recommend/_components/TransitionCard/index.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/TransitionCard/index.tsx
@@ -5,7 +5,7 @@ import { ObjectClassBadge } from "@/shared/components/ui/ObjectClassBadge";
 
 /** タイミング定数 */
 const CARD_MIN_MS = 500;
-const CARD_MAX_MS = 1000;
+const CARD_SAFETY_TIMEOUT_MS = 15_000;
 const FADE_DURATION_MS = 150;
 
 /** グラデーションマッピング */
@@ -136,10 +136,10 @@ export function TransitionCard({
       }
     }, CARD_MIN_MS);
 
-    // Max time → force fade out
+    // Safety timeout → iframe読み込みタイムアウトに合わせた安全弁（15秒）
     addTimer(() => {
       startFadeOut();
-    }, CARD_MAX_MS);
+    }, CARD_SAFETY_TIMEOUT_MS);
 
     return () => {
       cancelAnimationFrame(rafId);

--- a/apps/web/src/app/(main)/recommend/_hooks/useIframePool.ts
+++ b/apps/web/src/app/(main)/recommend/_hooks/useIframePool.ts
@@ -59,24 +59,17 @@ export const useIframePool = ({
     null,
   ]);
 
-  // articlesとcurrentIndexの変化に応じてスロットを同期
-  // - EMPTY_SLOT→実データの初期化（articles取得完了時）
-  // - currentIndex変更時のスロット再構築（goToNext後）
-  //
-  // NOTE: 本来はhandleIframeLoadによるcascade loadingでnext/prefetchを
-  // 段階的に作成する設計だが、page.tsxからhandleIframeLoadが接続されていないため、
-  // currentIndex変更をトリガーにスロットを再構築する方式で代替する。
+  // EMPTY_SLOT→実データの初期化（articles取得完了時のみ）
+  // advance() + handleIframeLoad cascade がスロット管理を担うため、
+  // currentIndex変更時の再構築は行わない（プリロード済みiframeを破棄しない）
   useEffect(() => {
     if (articles.length === 0) return;
 
     setSlots((prev) => {
-      if (prev[0].articleIndex === currentIndex) return prev;
+      // 初期化済み（EMPTY_SLOTでない）の場合は何もしない
+      if (prev[0].articleIndex !== -1) return prev;
 
-      return [
-        createSlot(articles, currentIndex) ?? EMPTY_SLOT,
-        createSlot(articles, currentIndex + 1),
-        createSlot(articles, currentIndex + 2),
-      ];
+      return [createSlot(articles, currentIndex) ?? EMPTY_SLOT, null, null];
     });
   }, [articles, currentIndex]);
 

--- a/apps/web/src/app/(main)/recommend/page.tsx
+++ b/apps/web/src/app/(main)/recommend/page.tsx
@@ -51,7 +51,11 @@ export default function RecommendPage() {
   const { add: addToHistory } = useHistory();
 
   // AC-2: iframeプール（3スロット）
-  const { slots, advance } = useIframePool({
+  const {
+    slots,
+    advance,
+    handleIframeLoad: poolHandleIframeLoad,
+  } = useIframePool({
     articles,
     currentIndex,
   });
@@ -70,6 +74,18 @@ export default function RecommendPage() {
   // iframe読み込み待ち（初回表示 + 遷移後の旧記事フラッシュ防止）
   // 初期値false: iframeのonLoad完了まで非表示にし、コンテンツ未描画状態の表示を防ぐ
   const [isSlotReady, setIsSlotReady] = useState(false);
+
+  // プリロード済みスロットがcurrentに昇格した場合、即座にisSlotReadyをtrueにする
+  // 初回レンダリング時はスキップ（初回はhandleCurrentIframeLoadで処理）
+  const currentSlotArticleIndex = slots[0].articleIndex;
+  const currentSlotLoaded = slots[0].isLoaded;
+  const prevSlotIndexRef = useRef(currentSlotArticleIndex);
+  useEffect(() => {
+    if (currentSlotArticleIndex !== prevSlotIndexRef.current && currentSlotLoaded) {
+      setIsSlotReady(true);
+    }
+    prevSlotIndexRef.current = currentSlotArticleIndex;
+  }, [currentSlotArticleIndex, currentSlotLoaded]);
 
   // AC-4: スクロール深度の追跡（最大到達深度を保持）
   const maxScrollDepthRef = useRef(0);
@@ -204,34 +220,36 @@ export default function RecommendPage() {
   // AC-2: iframeプールに基づくレンダリング
   return (
     <div className="relative h-screen overflow-hidden" data-testid="article-viewer">
-      {/* AC-2: Current スロット */}
-      <ArticleWebView
-        url={slots[0].url}
-        articleId={articles[slots[0].articleIndex]?.id}
-        onScrollChange={handleScrollChange}
-        onSkip={goToNext}
-        onContentLoaded={handleContentLoaded}
-        onIframeLoad={handleCurrentIframeLoad}
-        className={showCard || !isSlotReady ? "opacity-0" : "opacity-100"}
-      />
+      {/* AC-2: iframeプール（key付きでDOM保持 → プリロード有効化） */}
+      {slots.map((slot, i) => {
+        if (!slot) return null;
+        const isCurrent = i === 0;
+        const isVisible = isCurrent && !showCard && isSlotReady;
 
-      {/* AC-2: Next スロット（非表示、プリレンダリング） */}
-      {slots[1] && (
-        <ArticleWebView
-          url={slots[1].url}
-          articleId={articles[slots[1].articleIndex]?.id}
-          className="hidden"
-        />
-      )}
-
-      {/* AC-2: Prefetch スロット（非表示） */}
-      {slots[2] && (
-        <ArticleWebView
-          url={slots[2].url}
-          articleId={articles[slots[2].articleIndex]?.id}
-          className="hidden"
-        />
-      )}
+        return (
+          <ArticleWebView
+            key={`slot-${String(slot.articleIndex)}`}
+            url={slot.url}
+            articleId={articles[slot.articleIndex]?.id}
+            onScrollChange={isCurrent ? handleScrollChange : undefined}
+            onSkip={isCurrent ? goToNext : undefined}
+            onContentLoaded={isCurrent ? handleContentLoaded : undefined}
+            onIframeLoad={() => {
+              poolHandleIframeLoad(slot.articleIndex);
+              if (isCurrent) {
+                handleCurrentIframeLoad();
+              }
+            }}
+            className={
+              isVisible
+                ? "absolute inset-0 opacity-100 z-10"
+                : isCurrent
+                  ? "absolute inset-0 opacity-0 z-10"
+                  : "absolute inset-0 opacity-0 z-0 pointer-events-none"
+            }
+          />
+        );
+      })}
 
       {/* AC-1/AC-3: TransitionCard */}
       {nextArticleForCard && (


### PR DESCRIPTION
- TransitionCardの最大表示時間を1秒→15秒(安全弁)に変更し、
  iframe読み込み完了まで表示を継続する
- useIframePoolのhandleIframeLoadをpage.tsxに接続し、
  cascade loading（Current→Next→Prefetch）を正しく機能させる
- ArticleWebViewをkey付きリストレンダリングに変更し、
  advance()時にプリロード済みiframeのDOMを保持する
- プリロード済みスロットがcurrentに昇格した場合、
  即座にisSlotReady=trueを設定して白画面を防止する

https://claude.ai/code/session_0163QngCng7NWrtqaCzRcRHw