### PR TITLE
fix(e2e): add missing testIds and API mocks for E2E tests

### DIFF
--- a/apps/web/e2e/lib/mock-data.ts
+++ b/apps/web/e2e/lib/mock-data.ts
@@ -1,0 +1,98 @@
+/**
+ * E2Eテスト用モックデータ
+ *
+ * Playwright E2Eテストで使用するAPIレスポンスとlocalStorageデータの定義
+ */
+
+/** モック: POST /visitors レスポンス（オンボーディング完了済み） */
+export const mockVisitorOnboarded = {
+  visitorId: "e2e-test-visitor-001",
+  isNew: false,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  onboardingCompletedAt: "2024-01-01T00:00:00.000Z",
+};
+
+/** モック: POST /recommend レスポンス */
+export const mockRecommendResponse = {
+  recommendations: [
+    {
+      id: "scp-173",
+      title: "彫刻 - オリジナル",
+      similarityScore: 0.95,
+      source: "preference" as const,
+      url: "/wiki/scp-173",
+      objectClass: "Euclid",
+      rating: 1200,
+    },
+    {
+      id: "scp-049",
+      title: "ペスト医師",
+      similarityScore: 0.9,
+      source: "preference" as const,
+      url: "/wiki/scp-049",
+      objectClass: "Euclid",
+      rating: 980,
+    },
+    {
+      id: "scp-096",
+      title: "シャイガイ",
+      similarityScore: 0.85,
+      source: "serendipity" as const,
+      url: "/wiki/scp-096",
+      objectClass: "Euclid",
+      rating: 1100,
+    },
+  ],
+  count: 3,
+  hasMore: true,
+};
+
+/** モック: GET /favorites レスポンス */
+export const mockFavoritesResponse = {
+  favorites: [
+    {
+      id: "fav-001",
+      articleId: "scp-173",
+      title: "彫刻 - オリジナル",
+      excerpt: "アイテム番号: SCP-173 オブジェクトクラス: Euclid 特別収容プロトコル...",
+      objectClass: "Euclid",
+      rating: 1200,
+      favoritedAt: "2024-01-15T10:00:00.000Z",
+    },
+    {
+      id: "fav-002",
+      articleId: "scp-049",
+      title: "ペスト医師",
+      excerpt: "アイテム番号: SCP-049 オブジェクトクラス: Euclid 特別収容プロトコル...",
+      objectClass: "Euclid",
+      rating: 980,
+      favoritedAt: "2024-01-14T10:00:00.000Z",
+    },
+  ],
+  total: 2,
+};
+
+/** モック: 閲覧履歴エントリ（localStorage用） */
+export const mockHistoryEntries = [
+  {
+    scpNumber: "scp-173",
+    title: "彫刻 - オリジナル",
+    excerpt: "アイテム番号: SCP-173 オブジェクトクラス: Euclid",
+    objectClass: "Euclid",
+    viewedAt: "2024-01-15T12:00:00.000Z",
+  },
+  {
+    scpNumber: "scp-049",
+    title: "ペスト医師",
+    excerpt: "アイテム番号: SCP-049 オブジェクトクラス: Euclid",
+    objectClass: "Euclid",
+    viewedAt: "2024-01-15T11:00:00.000Z",
+  },
+];
+
+/** localStorageキー定義 */
+export const STORAGE_KEYS = {
+  visitorId: "recommend_scp_visitor_id",
+  onboardingCompleted: "recommend_scp_onboarding_completed",
+  history: "scp-history",
+} as const;

--- a/apps/web/e2e/lib/setup.ts
+++ b/apps/web/e2e/lib/setup.ts
@@ -1,0 +1,146 @@
+/**
+ * E2Eテスト用セットアップヘルパー
+ *
+ * Playwrightテストの前提条件（APIモック・localStorage設定）を管理
+ */
+import type { Page } from "@playwright/test";
+import {
+  mockVisitorOnboarded,
+  mockRecommendResponse,
+  mockFavoritesResponse,
+  mockHistoryEntries,
+  STORAGE_KEYS,
+} from "./mock-data";
+
+/**
+ * オンボーディング完了済みユーザーのAPIモックを設定
+ *
+ * POST /visitors → オンボーディング完了済みのレスポンスを返す
+ */
+export async function setupOnboardedVisitor(page: Page): Promise<void> {
+  await page.route("**/visitors", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockVisitorOnboarded),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * 推薦APIのモックを設定
+ *
+ * POST /recommend → テスト用記事データを返す
+ */
+export async function setupRecommendMock(page: Page): Promise<void> {
+  await page.route("**/recommend", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockRecommendResponse),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * お気に入りAPIのモックを設定
+ *
+ * GET /favorites → テスト用お気に入りデータを返す
+ * DELETE /favorites/:articleId → 204を返す
+ */
+export async function setupFavoritesMock(page: Page): Promise<void> {
+  await page.route("**/favorites**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockFavoritesResponse),
+      });
+    } else if (route.request().method() === "DELETE") {
+      await route.fulfill({ status: 204 });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * フィードバックAPIのモックを設定
+ *
+ * POST /feedback → 成功レスポンスを返す
+ * POST /favorites → 成功レスポンスを返す（お気に入り追加）
+ */
+export async function setupFeedbackMock(page: Page): Promise<void> {
+  await page.route("**/feedback", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+}
+
+/**
+ * 閲覧履歴のlocalStorageをシードする
+ */
+export async function seedHistory(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ storageKey, entries }) => {
+      localStorage.setItem(storageKey, JSON.stringify(entries));
+    },
+    { storageKey: STORAGE_KEYS.history, entries: mockHistoryEntries }
+  );
+}
+
+/**
+ * オンボーディング完了状態のlocalStorageを設定する
+ */
+export async function seedOnboardingCompleted(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ visitorIdKey, onboardingKey, visitorId }) => {
+      localStorage.setItem(visitorIdKey, visitorId);
+      localStorage.setItem(onboardingKey, "true");
+    },
+    {
+      visitorIdKey: STORAGE_KEYS.visitorId,
+      onboardingKey: STORAGE_KEYS.onboardingCompleted,
+      visitorId: mockVisitorOnboarded.visitorId,
+    }
+  );
+}
+
+/**
+ * 推薦画面テスト用のフルセットアップ
+ */
+export async function setupRecommendTest(page: Page): Promise<void> {
+  await setupOnboardedVisitor(page);
+  await setupRecommendMock(page);
+  await setupFeedbackMock(page);
+  await seedOnboardingCompleted(page);
+}
+
+/**
+ * お気に入り画面テスト用のフルセットアップ
+ */
+export async function setupFavoritesTest(page: Page): Promise<void> {
+  await setupOnboardedVisitor(page);
+  await setupFavoritesMock(page);
+  await seedOnboardingCompleted(page);
+}
+
+/**
+ * 閲覧履歴画面テスト用のフルセットアップ
+ */
+export async function setupHistoryTest(page: Page): Promise<void> {
+  await setupOnboardedVisitor(page);
+  await seedOnboardingCompleted(page);
+  await seedHistory(page);
+}

--- a/apps/web/e2e/specs/favorites.spec.ts
+++ b/apps/web/e2e/specs/favorites.spec.ts
@@ -3,11 +3,16 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "node:url";
 import { parseTestCaseCsv } from "../lib/csv-parser";
 import { executeSteps } from "../lib/step-executor";
+import { setupFavoritesTest } from "../lib/setup";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const testCases = parseTestCaseCsv(join(__dirname, "../lib/testcases/favorites.csv"));
 
 test.describe("お気に入り画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupFavoritesTest(page);
+  });
+
   for (const tc of testCases) {
     test(`${tc.name} @${tc.tags.join(" @")}`, async ({ page }) => {
       await executeSteps(page, tc.steps);

--- a/apps/web/e2e/specs/history.spec.ts
+++ b/apps/web/e2e/specs/history.spec.ts
@@ -3,11 +3,16 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "node:url";
 import { parseTestCaseCsv } from "../lib/csv-parser";
 import { executeSteps } from "../lib/step-executor";
+import { setupHistoryTest } from "../lib/setup";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const testCases = parseTestCaseCsv(join(__dirname, "../lib/testcases/history.csv"));
 
 test.describe("閲覧履歴画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupHistoryTest(page);
+  });
+
   for (const tc of testCases) {
     test(`${tc.name} @${tc.tags.join(" @")}`, async ({ page }) => {
       await executeSteps(page, tc.steps);

--- a/apps/web/e2e/specs/recommend.spec.ts
+++ b/apps/web/e2e/specs/recommend.spec.ts
@@ -3,11 +3,16 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "node:url";
 import { parseTestCaseCsv } from "../lib/csv-parser";
 import { executeSteps } from "../lib/step-executor";
+import { setupRecommendTest } from "../lib/setup";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const testCases = parseTestCaseCsv(join(__dirname, "../lib/testcases/recommend.csv"));
 
 test.describe("推薦画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupRecommendTest(page);
+  });
+
   for (const tc of testCases) {
     test(`${tc.name} @${tc.tags.join(" @")}`, async ({ page }) => {
       await executeSteps(page, tc.steps);

--- a/apps/web/src/app/onboarding/_components/PackSelector/PackCard.tsx
+++ b/apps/web/src/app/onboarding/_components/PackSelector/PackCard.tsx
@@ -22,6 +22,7 @@ const icons: Record<string, string> = {
 export function PackCard({ pack, isSelected, onSelect, disabled }: PackCardProps) {
   return (
     <button
+      data-testid={`pack-${pack.type}`}
       onClick={onSelect}
       disabled={disabled}
       className={`relative w-full rounded-2xl border-2 bg-white p-4 text-left shadow-sm transition-all ${

--- a/apps/web/src/app/onboarding/_components/PackSelector/index.tsx
+++ b/apps/web/src/app/onboarding/_components/PackSelector/index.tsx
@@ -114,6 +114,7 @@ export function PackSelector({ visitorId, onComplete }: PackSelectorProps) {
       {/* 開始ボタン（固定フッター） */}
       <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-t from-gray-50 via-gray-50 p-4">
         <button
+          data-testid="complete-button"
           onClick={() => {
             void handleConfirm();
           }}

--- a/apps/web/src/shared/components/ui/PillNav/PillNav.tsx
+++ b/apps/web/src/shared/components/ui/PillNav/PillNav.tsx
@@ -47,6 +47,7 @@ export const PillNav = ({ onFavorite, onNext, isFavorited }: PillNavProps) => {
       {/* お気に入りボタン */}
       <button
         type="button"
+        data-testid="floating-favorite-button"
         onClick={onFavorite}
         aria-label={isFavorited ? "お気に入りから削除" : "お気に入りに追加"}
         className={cn(


### PR DESCRIPTION
コンポーネントの不足していたdata-testidを追加:
- PackCard: pack-{type}形式のtestIdを追加（pack-horror等）
- PackSelector: complete-buttonのtestIdを追加
- PillNav: floating-favorite-buttonのtestIdを追加

E2EテストにbeforeEachセットアップを追加:
- recommend/favorites/history specにAPIルートモックを追加
- オンボーディング完了済みvisitorのモックで
  OnboardingGuardのリダイレクトを回避
- お気に入り・推薦APIのモックでテストデータを提供
- 閲覧履歴のlocalStorageシードでテストデータを提供

https://claude.ai/code/session_01NSsxALvDW41Ut25z2Stdp5