### PR TITLE
fix(recommend): プリロード済み記事の閲覧履歴が保存されない問題を修正

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
@@ -175,7 +175,14 @@ export function ArticleWebView({
   // mixed content回避: iframeにはプロキシURLを使用
   const iframeSrc = useMemo(() => toProxyUrl(url), [url]);
 
-  const { iframeRef, error, handleLoad, handleError, retry } = useArticleWebView({
+  const {
+    iframeRef,
+    isLoading: isIframeLoading,
+    error,
+    handleLoad,
+    handleError,
+    retry,
+  } = useArticleWebView({
     url: iframeSrc,
     onScrollEnd,
     onScrollChange,
@@ -193,6 +200,17 @@ export function ArticleWebView({
     articleId: articleId ?? "",
     onContentLoaded: handleContentLoaded,
   });
+
+  // プリロード済みスロットがcurrentに昇格した際のコンテンツ取得
+  // iframeのonLoadは一度しか発火しないため、non-currentスロットとしてロードされた場合、
+  // current昇格時にonContentLoadedが有効になってもhandleIframeLoadは再発火しない。
+  // このEffectで昇格後のfetchContentを補完する。
+  useEffect(() => {
+    if (!isIframeLoading && articleId && onContentLoaded && !contentFetchedRef.current) {
+      contentFetchedRef.current = true;
+      void fetchContent();
+    }
+  }, [isIframeLoading, articleId, onContentLoaded, fetchContent]);
 
   // WebView読み込み完了時にコンテンツ取得を実行
   const handleIframeLoad = useCallback(() => {


### PR DESCRIPTION
iframeプールのCascade Prefetch方式で、プリロード済みスロット（non-current）の
iframeロード時にonContentLoadedがundefinedのため、fetchContent()が実行されない
問題を修正。スロットがcurrentに昇格しても、iframeのonLoadは再発火しないため、
2件目以降の記事が閲覧履歴に保存されなかった。

useEffectを追加し、onContentLoadedが有効になった時点でiframeが既にロード済みの
場合にfetchContentを補完実行するようにした。

https://claude.ai/code/session_01YCKNfY6P9YBXu4b978qywn