### PR TITLE
fix(history): 閲覧履歴カードの表示をSCPナンバー・オブジェクトクラス・スター数に限定

### DIFF
--- a/apps/web/src/app/(main)/history/_components/HistoryCard/__dev__/HistoryCard.test.tsx
+++ b/apps/web/src/app/(main)/history/_components/HistoryCard/__dev__/HistoryCard.test.tsx
@@ -9,11 +9,6 @@ import { render, screen } from "@testing-library/react";
 import { HistoryCard } from "../index";
 import type { HistoryEntry } from "../../../_types";
 
-// formatRelativeTime のモック
-vi.mock("@/shared/lib/date", () => ({
-  formatRelativeTime: vi.fn(() => "2時間前"),
-}));
-
 // next/link のモック
 vi.mock("next/link", () => ({
   default: ({
@@ -36,8 +31,9 @@ describe("HistoryCard", () => {
   const mockEntry: HistoryEntry = {
     scpNumber: "scp-173",
     title: "彫刻 - オリジナル",
-    excerpt: "アイテム番号: SCP-173 オブジェクトクラス: Euclid 特別収容プロ",
+    excerpt: "",
     objectClass: "Euclid",
+    rating: 4102,
     viewedAt: "2024-01-15T10:00:00.000Z",
   };
 
@@ -51,51 +47,6 @@ describe("HistoryCard", () => {
     expect(screen.getByText("scp-173")).toBeInTheDocument();
   });
 
-  it("タイトルが表示される", () => {
-    render(<HistoryCard entry={mockEntry} />);
-
-    expect(screen.getByText("彫刻 - オリジナル")).toBeInTheDocument();
-  });
-
-  it("excerptがタイトル下に表示される（AC-4）", () => {
-    render(<HistoryCard entry={mockEntry} />);
-
-    const excerptElement = screen.getByText(
-      "アイテム番号: SCP-173 オブジェクトクラス: Euclid 特別収容プロ"
-    );
-    expect(excerptElement).toBeInTheDocument();
-  });
-
-  it("excerptがグレーのテキストカラーで表示される（AC-4）", () => {
-    render(<HistoryCard entry={mockEntry} />);
-
-    const excerptElement = screen.getByText(
-      "アイテム番号: SCP-173 オブジェクトクラス: Euclid 特別収容プロ"
-    );
-    expect(excerptElement).toHaveClass("text-gray-400");
-  });
-
-  it("excerptが1行に収まるよう省略される（AC-4）", () => {
-    render(<HistoryCard entry={mockEntry} />);
-
-    const excerptElement = screen.getByText(
-      "アイテム番号: SCP-173 オブジェクトクラス: Euclid 特別収容プロ"
-    );
-    expect(excerptElement).toHaveClass("truncate");
-  });
-
-  it("excerptが空の場合は表示しない（AC-5）", () => {
-    const entryWithoutExcerpt: HistoryEntry = {
-      ...mockEntry,
-      excerpt: "",
-    };
-
-    render(<HistoryCard entry={entryWithoutExcerpt} />);
-
-    // excerptの親要素（data-testid="excerpt"）が存在しないことを確認
-    expect(screen.queryByTestId("excerpt")).not.toBeInTheDocument();
-  });
-
   it("オブジェクトクラスバッジが表示される", () => {
     render(<HistoryCard entry={mockEntry} />);
 
@@ -106,22 +57,66 @@ describe("HistoryCard", () => {
     const entryWithoutObjectClass: HistoryEntry = {
       scpNumber: "scp-173",
       title: "彫刻 - オリジナル",
-      excerpt: "テスト",
+      excerpt: "",
       viewedAt: "2024-01-15T10:00:00.000Z",
     };
 
     render(<HistoryCard entry={entryWithoutObjectClass} />);
 
-    // Euclidなどのオブジェクトクラステキストが存在しないことを確認
     expect(screen.queryByText("Euclid")).not.toBeInTheDocument();
     expect(screen.queryByText("Safe")).not.toBeInTheDocument();
     expect(screen.queryByText("Keter")).not.toBeInTheDocument();
   });
 
-  it("閲覧時刻が相対時間で表示される", () => {
+  it("スター数がフォーマットされて表示される", () => {
     render(<HistoryCard entry={mockEntry} />);
 
-    expect(screen.getByText("2時間前")).toBeInTheDocument();
+    expect(screen.getByText("+4,102")).toBeInTheDocument();
+  });
+
+  it("スター数が負数の場合はマイナス符号付きで表示される", () => {
+    const entryWithNegativeRating: HistoryEntry = {
+      ...mockEntry,
+      rating: -15,
+    };
+
+    render(<HistoryCard entry={entryWithNegativeRating} />);
+
+    expect(screen.getByText("-15")).toBeInTheDocument();
+  });
+
+  it("スター数がnullの場合は表示しない", () => {
+    const entryWithoutRating: HistoryEntry = {
+      ...mockEntry,
+      rating: null,
+    };
+
+    render(<HistoryCard entry={entryWithoutRating} />);
+
+    // +4,102 が表示されていないことを確認
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it("スター数がundefinedの場合は表示しない", () => {
+    const entryWithoutRating: HistoryEntry = {
+      ...mockEntry,
+      rating: undefined,
+    };
+
+    render(<HistoryCard entry={entryWithoutRating} />);
+
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  it("excerptは表示されない", () => {
+    const entryWithExcerpt: HistoryEntry = {
+      ...mockEntry,
+      excerpt: "アイテム番号: SCP-173",
+    };
+
+    render(<HistoryCard entry={entryWithExcerpt} />);
+
+    expect(screen.queryByText("アイテム番号: SCP-173")).not.toBeInTheDocument();
   });
 
   it("カードをクリックすると記事詳細画面に遷移する（AC-1）", () => {

--- a/apps/web/src/app/(main)/history/_components/HistoryCard/index.tsx
+++ b/apps/web/src/app/(main)/history/_components/HistoryCard/index.tsx
@@ -1,11 +1,10 @@
 /**
  * @file HistoryCard コンポーネント
- * @description 閲覧履歴カードのUI
+ * @description 閲覧履歴カードのUI（お気に入りカードと同一レイアウト）
  * @see specs/006-frontend/006-04-history/006-04-03.md
  */
 
 import Link from "next/link";
-import { formatRelativeTime } from "@/shared/lib/date";
 import { ObjectClassBadge } from "@/shared/components/ui/ObjectClassBadge";
 import { Icon } from "@/shared/components/ui/Icon";
 import type { HistoryEntry } from "../../_types";
@@ -19,16 +18,32 @@ export interface HistoryCardProps {
 }
 
 /**
+ * 評価を表示用にフォーマット
+ * - 正数の場合は「+」を付与
+ * - 3桁区切りにフォーマット
+ */
+function formatRating(rating: number | null | undefined): string | null {
+  if (rating === null || rating === undefined) return null;
+  const prefix = rating >= 0 ? "+" : "";
+  return `${prefix}${rating.toLocaleString()}`;
+}
+
+/**
+ * objectClassを表示用にフォーマット（先頭大文字化）
+ */
+function formatObjectClass(objectClass: string | null | undefined): string | null {
+  if (!objectClass) return null;
+  return objectClass.charAt(0).toUpperCase() + objectClass.slice(1).toLowerCase();
+}
+
+/**
  * 履歴カードコンポーネント
+ *
+ * 表示項目: SCPナンバー、オブジェクトクラス、スター数
+ * お気に入りカードと同一のUIレイアウト
  *
  * AC-1: カードタップで記事詳細画面に遷移
  * AC-2: タップフィードバック（scale: 0.98）
- *
- * UI表示:
- * - タイトル下に excerpt が表示される
- * - グレーのテキストカラーで表示される
- * - 1行に収まるよう省略される
- * - excerpt が空の場合は表示しない
  *
  * @param props - コンポーネントProps
  * @returns 履歴カードコンポーネント
@@ -39,21 +54,17 @@ export interface HistoryCardProps {
  *   entry={{
  *     scpNumber: "scp-173",
  *     title: "彫刻 - オリジナル",
- *     excerpt: "アイテム番号: SCP-173",
+ *     excerpt: "",
  *     objectClass: "Euclid",
+ *     rating: 4102,
  *     viewedAt: "2024-01-15T10:00:00.000Z",
  *   }}
  * />
  * ```
  */
 export function HistoryCard({ entry }: HistoryCardProps) {
-  const badgeVariant = entry.objectClass?.toLowerCase() as
-    | "safe"
-    | "euclid"
-    | "keter"
-    | "thaumiel"
-    | "neutralized"
-    | undefined;
+  const formattedRating = formatRating(entry.rating);
+  const formattedObjectClass = formatObjectClass(entry.objectClass);
 
   return (
     <Link
@@ -63,23 +74,18 @@ export function HistoryCard({ entry }: HistoryCardProps) {
     >
       <div className="flex items-start gap-3">
         <div className="flex-1 min-w-0">
+          {/* バッジと評価 */}
           <div className="flex items-center gap-2 mb-1">
-            {/* objectClassがある場合のみバッジを表示 */}
-            {entry.objectClass && badgeVariant && (
-              <ObjectClassBadge variant={badgeVariant} className="flex-shrink-0">
-                {entry.objectClass}
+            {formattedObjectClass && (
+              <ObjectClassBadge variant={formattedObjectClass}>
+                {formattedObjectClass}
               </ObjectClassBadge>
             )}
+            {formattedRating && <span className="text-xs text-gray-400">{formattedRating}</span>}
           </div>
+
+          {/* SCPナンバー */}
           <h3 className="font-semibold text-gray-800">{entry.scpNumber}</h3>
-          <p className="text-sm text-gray-500 truncate">{entry.title}</p>
-          {/* 空の excerpt は表示しない */}
-          {entry.excerpt && (
-            <p data-testid="excerpt" className="text-xs text-gray-400 truncate mt-1">
-              {entry.excerpt}
-            </p>
-          )}
-          <p className="text-xs text-gray-400 mt-1">{formatRelativeTime(entry.viewedAt)}</p>
         </div>
 
         {/* 右矢印アイコン */}

--- a/apps/web/src/app/(main)/history/_lib/__dev__/historyStorage.test.ts
+++ b/apps/web/src/app/(main)/history/_lib/__dev__/historyStorage.test.ts
@@ -95,6 +95,34 @@ describe("historyStorage", () => {
       expect(result.excerpt).toBe("");
     });
 
+    it("ratingが保存される", () => {
+      const entry = {
+        scpNumber: "scp-173",
+        title: "彫刻",
+        excerpt: "",
+        objectClass: "Euclid" as const,
+        rating: 4102,
+      };
+
+      const result = addHistory(entry);
+
+      expect(result.rating).toBe(4102);
+      const history = getHistory();
+      expect(history[0].rating).toBe(4102);
+    });
+
+    it("ratingが未指定の場合はnullになる", () => {
+      const entry = {
+        scpNumber: "scp-173",
+        title: "彫刻",
+        objectClass: "Safe" as const,
+      };
+
+      const result = addHistory(entry as Parameters<typeof addHistory>[0]);
+
+      expect(result.rating).toBeNull();
+    });
+
     it("同じSCP番号の履歴は更新される（重複排除）", () => {
       addHistory({
         scpNumber: "scp-173",
@@ -207,6 +235,26 @@ describe("historyStorage", () => {
 
       expect(history).toHaveLength(1);
       expect(history[0].excerpt).toBe(""); // 空文字がデフォルト
+      expect(history[0].scpNumber).toBe("scp-173");
+    });
+
+    it("後方互換性: ratingがないデータでもエラーにならない", () => {
+      // 古い形式のデータ（ratingなし）を直接localStorageに書き込む
+      const oldData = [
+        {
+          scpNumber: "scp-173",
+          title: "彫刻",
+          excerpt: "テスト",
+          objectClass: "Euclid",
+          viewedAt: "2024-01-15T10:00:00.000Z",
+        },
+      ];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(oldData));
+
+      const history = getHistory();
+
+      expect(history).toHaveLength(1);
+      expect(history[0].rating).toBeNull();
       expect(history[0].scpNumber).toBe("scp-173");
     });
 

--- a/apps/web/src/app/(main)/history/_lib/historyStorage.ts
+++ b/apps/web/src/app/(main)/history/_lib/historyStorage.ts
@@ -17,6 +17,7 @@ const MAX_HISTORY_ITEMS = 100;
  */
 export type HistoryEntryInput = Omit<HistoryEntry, "viewedAt"> & {
   excerpt?: string;
+  rating?: number | null;
 };
 
 /**
@@ -41,6 +42,7 @@ export function addHistory(entry: HistoryEntryInput): HistoryEntry {
     title: entry.title,
     excerpt: entry.excerpt || "",
     objectClass: entry.objectClass,
+    rating: entry.rating ?? null,
     viewedAt: new Date().toISOString(),
   };
 
@@ -98,6 +100,7 @@ export function getHistory(): HistoryEntry[] {
         title: record.title as string,
         excerpt: typeof record.excerpt === "string" ? record.excerpt : "",
         objectClass: record.objectClass as ObjectClass,
+        rating: typeof record.rating === "number" ? record.rating : null,
         viewedAt: record.viewedAt as string,
       };
     });

--- a/apps/web/src/app/(main)/history/_types/index.ts
+++ b/apps/web/src/app/(main)/history/_types/index.ts
@@ -20,10 +20,12 @@ export interface HistoryEntry {
   scpNumber: string;
   /** 記事タイトル */
   title: string;
-  /** 本文冒頭（最大50文字） */
+  /** 本文冒頭（最大50文字）@deprecated excerptはカードに表示しない */
   excerpt: string;
   /** オブジェクトクラス（オプショナル） */
   objectClass?: ObjectClass;
+  /** 評価スコア（オプショナル） */
+  rating?: number | null;
   /** 閲覧日時（ISO 8601形式） */
   viewedAt: string;
 }

--- a/apps/web/src/app/(main)/recommend/page.tsx
+++ b/apps/web/src/app/(main)/recommend/page.tsx
@@ -17,6 +17,7 @@ import { useFeedback, calculateInterestLevel } from "./_hooks/useFeedback";
 import { useArticleFavorite } from "@/shared/hooks/useArticleFavorite";
 import { useIframePool } from "./_hooks/useIframePool";
 import { useHistory } from "@/app/(main)/history/_hooks/useHistory";
+import type { HistoryEntry } from "@/app/(main)/history/_types";
 import { ArticleWebView, type ArticleContent } from "./_components/ArticleWebView";
 import { FloatingUI } from "./_components/FloatingUI";
 import { TransitionCard } from "./_components/TransitionCard";
@@ -197,6 +198,8 @@ export default function RecommendPage() {
           scpNumber: currentArticle.id,
           title: content.title || currentArticle.title,
           excerpt: content.excerpt,
+          objectClass: (currentArticle.objectClass as HistoryEntry["objectClass"]) ?? undefined,
+          rating: currentArticle.rating,
         });
       }
     },


### PR DESCRIPTION
本文のexcerptから評価ボタン等の不要な要素がカードに表示される問題を修正。
お気に入りカードと同一のUIレイアウトに統一し、表示項目をSCPナンバー・
オブジェクトクラス・スター数の3つに限定した。

- HistoryEntry型にratingフィールドを追加
- 推薦画面からの履歴記録時にobjectClass・ratingを保存
- HistoryCardからexcerpt・タイトル・閲覧日時の表示を削除
- localStorageの後方互換性を維持（rating未保存データはnull扱い）

https://claude.ai/code/session_017BsTF6qf6vZPfKidkBsSbZ