### PR TITLE
refactor(recommend): articleWebViewのuseEffect群を責務単位のカスタムフックに分割

### DIFF
--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.test.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ArticleWebView } from "./ArticleWebView";
 
 // useArticleWebViewのモック
@@ -7,15 +7,27 @@ vi.mock("./useArticleWebView", () => ({
   useArticleWebView: vi.fn(),
 }));
 
-// use404Detectionのモック
-vi.mock("./use404Detection", () => ({
-  use404Detection: vi.fn(),
+// useIosSafariScrollFixのモック（副作用のみのフック）
+vi.mock("./useIosSafariScrollFix", () => ({
+  useIosSafariScrollFix: vi.fn(),
+}));
+
+// useNotFoundStateのモック
+vi.mock("./useNotFoundState", () => ({
+  useNotFoundState: vi.fn(),
+}));
+
+// useIframeLoadHandlerのモック
+vi.mock("./useIframeLoadHandler", () => ({
+  useIframeLoadHandler: vi.fn(),
 }));
 
 import { useArticleWebView } from "./useArticleWebView";
-import { use404Detection } from "./use404Detection";
+import { useNotFoundState } from "./useNotFoundState";
+import { useIframeLoadHandler } from "./useIframeLoadHandler";
 const mockUseArticleWebView = vi.mocked(useArticleWebView);
-const mockUse404Detection = vi.mocked(use404Detection);
+const mockUseNotFoundState = vi.mocked(useNotFoundState);
+const mockUseIframeLoadHandler = vi.mocked(useIframeLoadHandler);
 
 describe("ArticleWebView", () => {
   const createMockReturn = (overrides = {}) => ({
@@ -31,10 +43,12 @@ describe("ArticleWebView", () => {
 
   beforeEach(() => {
     mockUseArticleWebView.mockReturnValue(createMockReturn());
-    // use404Detectionのデフォルトモック（存在するURLとして扱う）
-    mockUse404Detection.mockReturnValue({
-      isChecking: false,
-      isNotFound: false,
+    mockUseNotFoundState.mockReturnValue({
+      showNotFound: false,
+      handleSuggest: vi.fn(),
+    });
+    mockUseIframeLoadHandler.mockReturnValue({
+      handleIframeLoad: vi.fn(),
     });
   });
 
@@ -195,6 +209,42 @@ describe("ArticleWebView", () => {
         expect.objectContaining({ onScrollChange })
       );
     });
+
+    it("useNotFoundStateにurl/articleId/onSkipが渡される", () => {
+      const onSkip = vi.fn();
+      render(<ArticleWebView url="https://example.com" articleId="scp-173" onSkip={onSkip} />);
+
+      expect(mockUseNotFoundState).toHaveBeenCalledWith({
+        url: "https://example.com",
+        articleId: "scp-173",
+        onSkip,
+      });
+    });
+
+    it("useIframeLoadHandlerに必要なオプションが渡される", () => {
+      const onContentLoaded = vi.fn();
+      const onIframeLoad = vi.fn();
+      const onContentFullyReady = vi.fn();
+      render(
+        <ArticleWebView
+          url="https://example.com"
+          articleId="scp-173"
+          onContentLoaded={onContentLoaded}
+          onIframeLoad={onIframeLoad}
+          onContentFullyReady={onContentFullyReady}
+        />
+      );
+
+      expect(mockUseIframeLoadHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com",
+          articleId: "scp-173",
+          onContentLoaded,
+          onIframeLoad,
+          onContentFullyReady,
+        })
+      );
+    });
   });
 
   describe("レイアウト", () => {
@@ -223,54 +273,35 @@ describe("ArticleWebView", () => {
   });
 
   describe("AC: 404検知・サジェスト画面", () => {
-    it("404検知時にサジェスト画面が表示される", async () => {
+    it("404検知時にサジェスト画面が表示される", () => {
       mockUseArticleWebView.mockReturnValue(createMockReturn({ isLoading: false }));
-
-      // onNotFoundコールバックをキャプチャして後から呼び出す
-      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
-      mockUse404Detection.mockImplementation(({ onNotFound }) => {
-        capturedOnNotFound = onNotFound;
-        return {
-          isChecking: false,
-          isNotFound: false,
-        };
+      mockUseNotFoundState.mockReturnValue({
+        showNotFound: true,
+        handleSuggest: vi.fn(),
       });
 
       render(
         <ArticleWebView url="https://example.com" articleId="test-article" onSkip={vi.fn()} />
       );
 
-      // コールバックをact内で呼び出す
-      await act(async () => {
-        await capturedOnNotFound?.();
-      });
-
       expect(screen.getByTestId("translation-not-found")).toBeInTheDocument();
     });
 
-    it("サジェスト画面でボタンクリック後にonSkipが呼ばれる", async () => {
-      const onSkip = vi.fn();
+    it("サジェスト画面でボタンクリック後にhandleSuggestが呼ばれる", () => {
+      const handleSuggest = vi.fn();
       mockUseArticleWebView.mockReturnValue(createMockReturn({ isLoading: false }));
-
-      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
-      mockUse404Detection.mockImplementation(({ onNotFound }) => {
-        capturedOnNotFound = onNotFound;
-        return {
-          isChecking: false,
-          isNotFound: false,
-        };
+      mockUseNotFoundState.mockReturnValue({
+        showNotFound: true,
+        handleSuggest,
       });
 
-      render(<ArticleWebView url="https://example.com" articleId="test-article" onSkip={onSkip} />);
-
-      // コールバックをact内で呼び出してサジェスト画面を表示
-      await act(async () => {
-        await capturedOnNotFound?.();
-      });
+      render(
+        <ArticleWebView url="https://example.com" articleId="test-article" onSkip={vi.fn()} />
+      );
 
       fireEvent.click(screen.getByRole("button", { name: "別の記事をおすすめ" }));
 
-      expect(onSkip).toHaveBeenCalledTimes(1);
+      expect(handleSuggest).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/ArticleWebView.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useCallback, useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo } from "react";
 import { cn } from "@/shared/lib/utils";
 import { useArticleWebView } from "./useArticleWebView";
-import { use404Detection } from "./use404Detection";
-import { useArticleContent } from "./useArticleContent";
+import { useIosSafariScrollFix } from "./useIosSafariScrollFix";
+import { useNotFoundState } from "./useNotFoundState";
+import { useIframeLoadHandler } from "./useIframeLoadHandler";
 import { TranslationNotFound } from "../TranslationNotFound";
 import type { ArticleWebViewProps } from "./index";
 
@@ -22,61 +23,6 @@ function toProxyUrl(url: string): string {
   return url;
 }
 
-/** iframe内画像の読み込みタイムアウト（個別画像ごと） */
-const IMAGE_LOAD_TIMEOUT_MS = 10_000;
-
-/**
- * iframe内の全画像が読み込み完了するまで待機
- *
- * wiki-proxy経由の同一オリジンiframeなので contentDocument にアクセス可能。
- * 各imgの .complete を確認し、未完了のものは load/error イベントで完了を待つ。
- * 個別画像のタイムアウト（10秒）を設け、永久待ちを防止する。
- */
-function waitForIframeImages(iframe: HTMLIFrameElement): Promise<void> {
-  return new Promise((resolve) => {
-    let doc: Document | null = null;
-    try {
-      doc = iframe.contentDocument;
-    } catch {
-      // Cross-origin（通常はwiki-proxy経由なので発生しない）
-      resolve();
-      return;
-    }
-    if (!doc) {
-      resolve();
-      return;
-    }
-
-    const images = Array.from(doc.querySelectorAll("img"));
-    const incompleteImages = images.filter((img) => !img.complete);
-
-    if (incompleteImages.length === 0) {
-      resolve();
-      return;
-    }
-
-    let remaining = incompleteImages.length;
-    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
-
-    const onDone = () => {
-      remaining--;
-      if (remaining <= 0) {
-        timeoutIds.forEach((id) => {
-          clearTimeout(id);
-        });
-        resolve();
-      }
-    };
-
-    incompleteImages.forEach((img) => {
-      img.addEventListener("load", onDone, { once: true });
-      img.addEventListener("error", onDone, { once: true });
-      // 個別画像タイムアウト: ネットワーク障害等で永久に読み込めない画像の安全弁
-      timeoutIds.push(setTimeout(onDone, IMAGE_LOAD_TIMEOUT_MS));
-    });
-  });
-}
-
 export function ArticleWebView({
   url,
   articleId,
@@ -89,92 +35,12 @@ export function ArticleWebView({
   isVisible,
   className,
 }: ArticleWebViewProps) {
-  const [showNotFound, setShowNotFound] = useState(false);
-  const contentFetchedRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // URL変更時にshowNotFoundをリセット（EMPTY_SLOT→実URL遷移時の防御）
-  useEffect(() => {
-    setShowNotFound(false);
-    contentFetchedRef.current = false;
-  }, [url]);
-
-  // iOS Safari/Chrome: プリロード→表示昇格時のスクロール復元
-  // pointer-events-none + opacity-0状態で読み込まれたiframeは、iOS WebKitでスクロール
-  // 領域が正しく計算されない。表示に切り替わったタイミングで以下を実施:
-  // 1. containerのheightトグルによるリフロー強制
-  // 2. iframeのwidthを微小変更→復元でiframe自体のレイアウト再計算
-  // 3. contentWindowのscrollTo(0,0)でスクロールエンジンの初期化
-  const prevVisibleRef = useRef(false);
-  useEffect(() => {
-    if (isVisible && !prevVisibleRef.current) {
-      const container = containerRef.current;
-      const iframe = iframeRef.current;
-      if (container) {
-        container.style.height = "auto";
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            container.style.height = "";
-            // iframe自体のサイズを微小変更→復元でレイアウト再計算を強制
-            if (iframe) {
-              iframe.style.width = "calc(100% - 1px)";
-              requestAnimationFrame(() => {
-                iframe.style.width = "";
-                // contentWindowのスクロールエンジンをリセット
-                try {
-                  iframe.contentWindow?.scrollTo(0, 0);
-                } catch {
-                  // cross-origin fallback
-                }
-              });
-            }
-          });
-        });
-      }
-    }
-    prevVisibleRef.current = !!isVisible;
-  }, [isVisible]);
-
-  // iOS Safari フォールバック: 初回タッチ時のリフロー強制
-  // 表示昇格時のリフローだけではタイミングが合わずスクロール不可になるケースがある。
-  // ユーザーが最初にタッチした瞬間にリフローを再実行し、確実にスクロール可能にする。
-  // once: trueで1回だけ発火し、以降はオーバーヘッドなし。
-  useEffect(() => {
-    if (!isVisible) return;
-    const iframe = iframeRef.current;
-    const container = containerRef.current;
-    if (!iframe || !container) return;
-
-    let iframeWindow: Window | null = null;
-    try {
-      iframeWindow = iframe.contentWindow;
-    } catch {
-      return;
-    }
-    if (!iframeWindow) return;
-
-    const onFirstTouch = () => {
-      container.style.height = "auto";
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          container.style.height = "";
-        });
-      });
-    };
-
-    iframeWindow.addEventListener("touchstart", onFirstTouch, { once: true, passive: true });
-    return () => {
-      try {
-        iframeWindow.removeEventListener("touchstart", onFirstTouch);
-      } catch {
-        // iframe may have navigated away
-      }
-    };
-  }, [isVisible]);
 
   // mixed content回避: iframeにはプロキシURLを使用
   const iframeSrc = useMemo(() => toProxyUrl(url), [url]);
 
+  // iframe管理（ローディング・スクロール検知・エラー処理）
   const {
     iframeRef,
     isLoading: isIframeLoading,
@@ -188,94 +54,28 @@ export function ArticleWebView({
     onScrollChange,
   });
 
-  // コンテンツ取得（タイトル・本文冒頭）
-  const handleContentLoaded = useCallback(
-    (content: { title: string; excerpt: string }) => {
-      onContentLoaded?.(content);
-    },
-    [onContentLoaded]
-  );
+  // iOS Safari: プリロード→表示昇格時のスクロール修正
+  useIosSafariScrollFix({ isVisible, containerRef, iframeRef });
 
-  const { fetchContent } = useArticleContent({
-    articleId: articleId ?? "",
-    onContentLoaded: handleContentLoaded,
-  });
-
-  // プリロード済みスロットがcurrentに昇格した際のコンテンツ取得
-  // iframeのonLoadは一度しか発火しないため、non-currentスロットとしてロードされた場合、
-  // current昇格時にonContentLoadedが有効になってもhandleIframeLoadは再発火しない。
-  // このEffectで昇格後のfetchContentを補完する。
-  useEffect(() => {
-    if (!isIframeLoading && articleId && onContentLoaded && !contentFetchedRef.current) {
-      contentFetchedRef.current = true;
-      void fetchContent();
-    }
-  }, [isIframeLoading, articleId, onContentLoaded, fetchContent]);
-
-  // WebView読み込み完了時にコンテンツ取得を実行
-  const handleIframeLoad = useCallback(() => {
-    handleLoad();
-    onIframeLoad?.(); // 即時: プールカスケード制御用
-
-    const iframe = iframeRef.current;
-
-    // iOS Safari iframe スクロール修正: 親divのheightを一瞬除去してリフローを強制。
-    // iOS Safariではiframe親コンテナのスクロール領域が初回レンダリング時に正しく計算されない。
-    // DevToolsでh-screenのチェックを外す→戻す操作で治ることから、
-    // 2回のペイントサイクルを経てheightをトグルする必要がある（double rAF）。
-    const container = containerRef.current;
-    if (container) {
-      container.style.height = "auto";
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          container.style.height = "";
-        });
-      });
-    }
-
-    // articleIdが指定されており、まだ取得していない場合のみ実行
-    if (articleId && onContentLoaded && !contentFetchedRef.current) {
-      contentFetchedRef.current = true;
-      void fetchContent();
-    }
-
-    // 画像含む全サブリソース読み込み完了を待ってから通知
-    if (iframe && onContentFullyReady) {
-      void waitForIframeImages(iframe).then(() => {
-        onContentFullyReady();
-      });
-    }
-  }, [handleLoad, onIframeLoad, onContentFullyReady, articleId, onContentLoaded, fetchContent]);
-
-  // 404検知時の処理
-  const handleNotFound = useCallback(async () => {
-    // DB更新（翻訳なしに設定）
-    if (articleId) {
-      try {
-        await fetch(`/api/articles/${articleId}/translation`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ lang: "ja", hasTranslation: false }),
-        });
-      } catch {
-        // API呼び出し失敗してもサジェスト画面は表示
-      }
-    }
-
-    setShowNotFound(true);
-  }, [articleId]);
-
-  // 404検知（バックグラウンドで実行、ローディング表示をブロックしない）
-  use404Detection({
+  // 404検知・NotFound UI状態管理
+  const { showNotFound, handleSuggest } = useNotFoundState({
     url,
-    onNotFound: handleNotFound,
+    articleId,
+    onSkip,
   });
 
-  // 次の記事に遷移
-  const handleSuggest = useCallback(() => {
-    setShowNotFound(false);
-    onSkip?.();
-  }, [onSkip]);
+  // iframeロード後のコンテンツ取得ライフサイクル
+  const { handleIframeLoad } = useIframeLoadHandler({
+    url,
+    articleId,
+    isIframeLoading,
+    iframeRef,
+    containerRef,
+    handleLoad,
+    onContentLoaded,
+    onIframeLoad,
+    onContentFullyReady,
+  });
 
   // サジェスト画面表示（通常のArticleWebViewと同じ高さを維持し、次記事が見えないようにする）
   if (showNotFound) {

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/index.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/index.tsx
@@ -27,6 +27,9 @@ export { ArticleWebView } from "./ArticleWebView";
 export { useArticleWebView } from "./useArticleWebView";
 export { use404Detection } from "./use404Detection";
 export { useArticleContent } from "./useArticleContent";
+export { useIosSafariScrollFix } from "./useIosSafariScrollFix";
+export { useNotFoundState } from "./useNotFoundState";
+export { useIframeLoadHandler } from "./useIframeLoadHandler";
 export type {
   ArticleContent,
   UseArticleContentOptions,

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIframeLoadHandler.test.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIframeLoadHandler.test.ts
@@ -1,0 +1,370 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useIframeLoadHandler } from "./useIframeLoadHandler";
+import type { RefObject } from "react";
+
+// useArticleContentのモック
+vi.mock("./useArticleContent", () => ({
+  useArticleContent: vi.fn(),
+}));
+
+import { useArticleContent } from "./useArticleContent";
+const mockUseArticleContent = vi.mocked(useArticleContent);
+
+function createMockContainerRef(): RefObject<HTMLDivElement | null> {
+  return {
+    current: {
+      style: { height: "" },
+    } as unknown as HTMLDivElement,
+  };
+}
+
+function createMockIframeRef(options?: { withImages?: boolean }) {
+  const images = options?.withImages
+    ? [
+        {
+          complete: false,
+          addEventListener: vi.fn((_, cb: () => void) => {
+            cb();
+          }),
+        },
+      ]
+    : [];
+
+  const element = {
+    contentDocument: {
+      querySelectorAll: vi.fn(() => images),
+    },
+    style: { width: "" },
+  } as unknown as HTMLIFrameElement;
+
+  return { current: element };
+}
+
+describe("useIframeLoadHandler", () => {
+  const mockFetchContent = vi.fn(() => Promise.resolve());
+
+  beforeEach(() => {
+    mockUseArticleContent.mockReturnValue({
+      fetchContent: mockFetchContent,
+      isLoading: false,
+    });
+
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("初期状態", () => {
+    it("handleIframeLoadが関数として返される", () => {
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: { current: null },
+          handleLoad: vi.fn(),
+        })
+      );
+
+      expect(typeof result.current.handleIframeLoad).toBe("function");
+    });
+  });
+
+  describe("handleIframeLoad", () => {
+    it("handleLoad（親フック）を呼び出す", () => {
+      const handleLoad = vi.fn();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad,
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(handleLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it("onIframeLoadコールバックを呼び出す", () => {
+      const onIframeLoad = vi.fn();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onIframeLoad,
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(onIframeLoad).toHaveBeenCalledTimes(1);
+    });
+
+    it("containerのheightトグル（iOS Safariリフロー）を実行する", () => {
+      const containerRef = createMockContainerRef();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef,
+          handleLoad: vi.fn(),
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      // rAFが同期実行されるため、最終的にheightが復元される
+      expect(containerRef.current!.style.height).toBe("");
+    });
+
+    it("articleIdとonContentLoadedがある場合にfetchContentを呼び出す", () => {
+      const onContentLoaded = vi.fn();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(mockFetchContent).toHaveBeenCalledTimes(1);
+    });
+
+    it("articleIdがない場合にfetchContentを呼び出さない", () => {
+      const onContentLoaded = vi.fn();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(mockFetchContent).not.toHaveBeenCalled();
+    });
+
+    it("onContentLoadedがない場合にfetchContentを呼び出さない", () => {
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(mockFetchContent).not.toHaveBeenCalled();
+    });
+
+    it("2回呼び出してもfetchContentは1回のみ（重複防止）", () => {
+      const onContentLoaded = vi.fn();
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+      act(() => {
+        result.current.handleIframeLoad();
+      });
+
+      expect(mockFetchContent).toHaveBeenCalledTimes(1);
+    });
+
+    it("onContentFullyReady指定時にiframe画像読み込み完了後にコールバックされる", async () => {
+      const onContentFullyReady = vi.fn();
+      const iframeRef = createMockIframeRef();
+
+      const { result } = renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef,
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentFullyReady,
+        })
+      );
+
+      await act(async () => {
+        result.current.handleIframeLoad();
+        // waitForIframeImages内部のPromiseを解決するためマイクロタスクをフラッシュ
+        await Promise.resolve();
+      });
+
+      expect(onContentFullyReady).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("プリロード昇格時のコンテンツ取得（Effect）", () => {
+    it("isIframeLoading=false + articleId + onContentLoadedの条件でfetchContentが呼ばれる", () => {
+      const onContentLoaded = vi.fn();
+
+      renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: false,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      expect(mockFetchContent).toHaveBeenCalledTimes(1);
+    });
+
+    it("isIframeLoading=trueの場合はfetchContentが呼ばれない", () => {
+      const onContentLoaded = vi.fn();
+
+      renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      expect(mockFetchContent).not.toHaveBeenCalled();
+    });
+
+    it("articleIdがない場合はfetchContentが呼ばれない", () => {
+      const onContentLoaded = vi.fn();
+
+      renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: false,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+          onContentLoaded,
+        })
+      );
+
+      expect(mockFetchContent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("URL変更時のリセット", () => {
+    it("URL変更後にisIframeLoadingがfalseに戻るとfetchContentが再度呼ばれる", () => {
+      const onContentLoaded = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ url, isIframeLoading }) =>
+          useIframeLoadHandler({
+            url,
+            articleId: "scp-173",
+            isIframeLoading,
+            iframeRef: { current: null },
+            containerRef: createMockContainerRef(),
+            handleLoad: vi.fn(),
+            onContentLoaded,
+          }),
+        { initialProps: { url: "https://example.com/1", isIframeLoading: false } }
+      );
+
+      expect(mockFetchContent).toHaveBeenCalledTimes(1);
+      mockFetchContent.mockClear();
+
+      // URL変更 + ローディング状態に戻る（新しいiframe読み込み開始）
+      rerender({ url: "https://example.com/2", isIframeLoading: true });
+      expect(mockFetchContent).not.toHaveBeenCalled();
+
+      // iframe読み込み完了 → contentFetchedRefがリセット済みなので再度fetchContent
+      rerender({ url: "https://example.com/2", isIframeLoading: false });
+      expect(mockFetchContent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("useArticleContentへのパラメータ渡し", () => {
+    it("articleIdがuseArticleContentに渡される", () => {
+      renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          articleId: "scp-173",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+        })
+      );
+
+      expect(mockUseArticleContent).toHaveBeenCalledWith(
+        expect.objectContaining({ articleId: "scp-173" })
+      );
+    });
+
+    it("articleId未指定時に空文字列が渡される", () => {
+      renderHook(() =>
+        useIframeLoadHandler({
+          url: "https://example.com",
+          isIframeLoading: true,
+          iframeRef: { current: null },
+          containerRef: createMockContainerRef(),
+          handleLoad: vi.fn(),
+        })
+      );
+
+      expect(mockUseArticleContent).toHaveBeenCalledWith(
+        expect.objectContaining({ articleId: "" })
+      );
+    });
+  });
+});

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIframeLoadHandler.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIframeLoadHandler.ts
@@ -1,0 +1,177 @@
+"use client";
+
+import { useCallback, useRef, useEffect, type RefObject } from "react";
+import { useArticleContent, type ArticleContent } from "./useArticleContent";
+
+/** iframe内画像の読み込みタイムアウト（個別画像ごと） */
+const IMAGE_LOAD_TIMEOUT_MS = 10_000;
+
+/**
+ * iframe内の全画像が読み込み完了するまで待機
+ *
+ * wiki-proxy経由の同一オリジンiframeなので contentDocument にアクセス可能。
+ * 各imgの .complete を確認し、未完了のものは load/error イベントで完了を待つ。
+ * 個別画像のタイムアウト（10秒）を設け、永久待ちを防止する。
+ */
+function waitForIframeImages(iframe: HTMLIFrameElement): Promise<void> {
+  return new Promise((resolve) => {
+    let doc: Document | null = null;
+    try {
+      doc = iframe.contentDocument;
+    } catch {
+      resolve();
+      return;
+    }
+    if (!doc) {
+      resolve();
+      return;
+    }
+
+    const images = Array.from(doc.querySelectorAll("img"));
+    const incompleteImages = images.filter((img) => !img.complete);
+
+    if (incompleteImages.length === 0) {
+      resolve();
+      return;
+    }
+
+    let remaining = incompleteImages.length;
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+
+    const onDone = () => {
+      remaining--;
+      if (remaining <= 0) {
+        timeoutIds.forEach((id) => {
+          clearTimeout(id);
+        });
+        resolve();
+      }
+    };
+
+    incompleteImages.forEach((img) => {
+      img.addEventListener("load", onDone, { once: true });
+      img.addEventListener("error", onDone, { once: true });
+      timeoutIds.push(setTimeout(onDone, IMAGE_LOAD_TIMEOUT_MS));
+    });
+  });
+}
+
+interface UseIframeLoadHandlerOptions {
+  /** 現在のURL（変更時にcontentFetchedRefをリセット） */
+  url: string;
+  /** 記事ID */
+  articleId?: string;
+  /** iframeがロード中かどうか（useArticleWebViewから取得） */
+  isIframeLoading: boolean;
+  /** iframeのRef */
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  /** コンテナのRef（iOS reflow用） */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** useArticleWebViewのhandleLoad */
+  handleLoad: () => void;
+  /** コンテンツ取得完了時のコールバック */
+  onContentLoaded?: (content: ArticleContent) => void;
+  /** iframe読み込み完了時のコールバック（カスケード先読み用） */
+  onIframeLoad?: () => void;
+  /** 全サブリソース読み込み完了時のコールバック */
+  onContentFullyReady?: () => void;
+}
+
+interface UseIframeLoadHandlerReturn {
+  /** iframeのonLoadイベントハンドラー */
+  handleIframeLoad: () => void;
+}
+
+/**
+ * iframeロード後のコンテンツ取得ライフサイクルを管理するフック
+ *
+ * - iframe onLoad時: 親フックのhandleLoad呼び出し、iOS reflow、コンテンツ取得、画像待機
+ * - プリロード昇格時: isIframeLoading=falseになったタイミングでのコンテンツ取得補完
+ * - URL変更時: contentFetchedRefリセット
+ */
+export function useIframeLoadHandler(
+  options: UseIframeLoadHandlerOptions
+): UseIframeLoadHandlerReturn {
+  const {
+    url,
+    articleId,
+    isIframeLoading,
+    iframeRef,
+    containerRef,
+    handleLoad,
+    onContentLoaded,
+    onIframeLoad,
+    onContentFullyReady,
+  } = options;
+
+  const contentFetchedRef = useRef(false);
+
+  // コンテンツ取得コールバック
+  const handleContentLoaded = useCallback(
+    (content: ArticleContent) => {
+      onContentLoaded?.(content);
+    },
+    [onContentLoaded]
+  );
+
+  const { fetchContent } = useArticleContent({
+    articleId: articleId ?? "",
+    onContentLoaded: handleContentLoaded,
+  });
+
+  // URL変更時にcontentFetchedRefをリセット
+  useEffect(() => {
+    contentFetchedRef.current = false;
+  }, [url]);
+
+  // プリロード済みスロットがcurrentに昇格した際のコンテンツ取得
+  useEffect(() => {
+    if (!isIframeLoading && articleId && onContentLoaded && !contentFetchedRef.current) {
+      contentFetchedRef.current = true;
+      void fetchContent();
+    }
+  }, [isIframeLoading, articleId, onContentLoaded, fetchContent]);
+
+  // iframeのonLoadイベントハンドラー
+  const handleIframeLoad = useCallback(() => {
+    handleLoad();
+    onIframeLoad?.();
+
+    const iframe = iframeRef.current;
+
+    // iOS Safari iframe スクロール修正: heightトグル
+    const container = containerRef.current;
+    if (container) {
+      container.style.height = "auto";
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          container.style.height = "";
+        });
+      });
+    }
+
+    // コンテンツ取得（重複防止）
+    if (articleId && onContentLoaded && !contentFetchedRef.current) {
+      contentFetchedRef.current = true;
+      void fetchContent();
+    }
+
+    // 画像含む全サブリソース読み込み完了を待ってから通知
+    if (iframe && onContentFullyReady) {
+      void waitForIframeImages(iframe).then(() => {
+        onContentFullyReady();
+      });
+    }
+  }, [
+    handleLoad,
+    onIframeLoad,
+    onContentFullyReady,
+    articleId,
+    onContentLoaded,
+    fetchContent,
+    iframeRef,
+    containerRef,
+  ]);
+
+  return { handleIframeLoad };
+}

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIosSafariScrollFix.test.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIosSafariScrollFix.test.ts
@@ -1,0 +1,289 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useIosSafariScrollFix } from "./useIosSafariScrollFix";
+import type { RefObject } from "react";
+
+/**
+ * コンテナRefのモック生成
+ */
+function createMockContainerRef(): RefObject<HTMLDivElement | null> {
+  const element = {
+    style: { height: "", width: "" },
+  } as unknown as HTMLDivElement;
+  return { current: element };
+}
+
+/**
+ * iframeRefのモック生成（contentWindow付き）
+ */
+function createMockIframeRef(options?: { crossOrigin?: boolean }) {
+  const listeners = new Map<string, EventListener>();
+  const contentWindow = {
+    scrollTo: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: EventListener) => {
+      listeners.set(event, handler);
+    }),
+    removeEventListener: vi.fn((event: string) => {
+      listeners.delete(event);
+    }),
+  };
+
+  const element = options?.crossOrigin
+    ? ({
+        get contentWindow(): never {
+          throw new DOMException("cross-origin");
+        },
+        style: { width: "" },
+      } as unknown as HTMLIFrameElement)
+    : ({
+        contentWindow,
+        style: { width: "" },
+      } as unknown as HTMLIFrameElement);
+
+  const ref: RefObject<HTMLIFrameElement | null> = { current: element };
+
+  return { ref, contentWindow, listeners };
+}
+
+describe("useIosSafariScrollFix", () => {
+  let rafCallbacks: FrameRequestCallback[];
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  /** rAFキューを全て実行 */
+  function flushRaf() {
+    while (rafCallbacks.length > 0) {
+      const cbs = [...rafCallbacks];
+      rafCallbacks = [];
+      cbs.forEach((cb) => {
+        cb(0);
+      });
+    }
+  }
+
+  describe("表示昇格時のリフロー", () => {
+    it("isVisible=falseからtrueに変化した時にコンテナのheightトグルが実行される", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef } = createMockIframeRef();
+
+      const { rerender } = renderHook(
+        ({ isVisible }) => {
+          useIosSafariScrollFix({ isVisible, containerRef, iframeRef });
+        },
+        { initialProps: { isVisible: false } }
+      );
+
+      rerender({ isVisible: true });
+
+      // heightが"auto"にセットされている
+      expect(containerRef.current!.style.height).toBe("auto");
+
+      // rAFを2回フラッシュして復元
+      flushRaf();
+      expect(containerRef.current!.style.height).toBe("");
+    });
+
+    it("isVisible=falseからtrueに変化した時にiframeのwidthが微小変更→復元される", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef } = createMockIframeRef();
+
+      const { rerender } = renderHook(
+        ({ isVisible }) => {
+          useIosSafariScrollFix({ isVisible, containerRef, iframeRef });
+        },
+        { initialProps: { isVisible: false } }
+      );
+
+      rerender({ isVisible: true });
+      flushRaf();
+
+      // width復元後は""に戻る
+      expect((iframeRef.current! as unknown as { style: CSSStyleDeclaration }).style.width).toBe(
+        ""
+      );
+    });
+
+    it("isVisible=falseからtrueに変化した時にcontentWindow.scrollTo(0,0)が呼ばれる", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, contentWindow } = createMockIframeRef();
+
+      const { rerender } = renderHook(
+        ({ isVisible }) => {
+          useIosSafariScrollFix({ isVisible, containerRef, iframeRef });
+        },
+        { initialProps: { isVisible: false } }
+      );
+
+      rerender({ isVisible: true });
+      flushRaf();
+
+      expect(contentWindow.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it("isVisible=trueのままrerenderしてもリフローは実行されない", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, contentWindow } = createMockIframeRef();
+
+      const { rerender } = renderHook(
+        ({ isVisible }) => {
+          useIosSafariScrollFix({ isVisible, containerRef, iframeRef });
+        },
+        { initialProps: { isVisible: true } }
+      );
+
+      // 初回rAFを消化
+      flushRaf();
+      contentWindow.scrollTo.mockClear();
+
+      rerender({ isVisible: true });
+      flushRaf();
+
+      // 2回目のrerenderではscrollToが呼ばれない
+      expect(contentWindow.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("cross-originのiframeでもエラーにならない", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef } = createMockIframeRef({ crossOrigin: true });
+
+      expect(() => {
+        renderHook(() => {
+          useIosSafariScrollFix({
+            isVisible: true,
+            containerRef,
+            iframeRef,
+          });
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("初回タッチフォールバック", () => {
+    it("isVisible=trueの時にtouchstartリスナーが登録される", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, contentWindow } = createMockIframeRef();
+
+      renderHook(() => {
+        useIosSafariScrollFix({
+          isVisible: true,
+          containerRef,
+          iframeRef,
+        });
+      });
+
+      expect(contentWindow.addEventListener).toHaveBeenCalledWith(
+        "touchstart",
+        expect.any(Function),
+        { once: true, passive: true }
+      );
+    });
+
+    it("isVisible=falseの時にtouchstartリスナーが登録されない", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, contentWindow } = createMockIframeRef();
+
+      renderHook(() => {
+        useIosSafariScrollFix({
+          isVisible: false,
+          containerRef,
+          iframeRef,
+        });
+      });
+
+      expect(contentWindow.addEventListener).not.toHaveBeenCalledWith(
+        "touchstart",
+        expect.any(Function),
+        expect.anything()
+      );
+    });
+
+    it("touchstart発火時にコンテナのheightトグルが実行される", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, listeners } = createMockIframeRef();
+
+      renderHook(() => {
+        useIosSafariScrollFix({
+          isVisible: true,
+          containerRef,
+          iframeRef,
+        });
+      });
+
+      // touchstartハンドラーを取得して呼び出し
+      const touchHandler = listeners.get("touchstart");
+      expect(touchHandler).toBeDefined();
+
+      act(() => {
+        touchHandler!(new Event("touchstart"));
+      });
+
+      expect(containerRef.current!.style.height).toBe("auto");
+      flushRaf();
+      expect(containerRef.current!.style.height).toBe("");
+    });
+
+    it("アンマウント時にtouchstartリスナーが解除される", () => {
+      const containerRef = createMockContainerRef();
+      const { ref: iframeRef, contentWindow } = createMockIframeRef();
+
+      const { unmount } = renderHook(() => {
+        useIosSafariScrollFix({
+          isVisible: true,
+          containerRef,
+          iframeRef,
+        });
+      });
+
+      unmount();
+
+      expect(contentWindow.removeEventListener).toHaveBeenCalledWith(
+        "touchstart",
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe("Ref未設定時の安全性", () => {
+    it("containerRef.current=nullでもエラーにならない", () => {
+      const containerRef: RefObject<HTMLDivElement | null> = { current: null };
+      const { ref: iframeRef } = createMockIframeRef();
+
+      expect(() => {
+        renderHook(() => {
+          useIosSafariScrollFix({
+            isVisible: true,
+            containerRef,
+            iframeRef,
+          });
+        });
+      }).not.toThrow();
+    });
+
+    it("iframeRef.current=nullでもエラーにならない", () => {
+      const containerRef = createMockContainerRef();
+      const iframeRef: RefObject<HTMLIFrameElement | null> = { current: null };
+
+      expect(() => {
+        renderHook(() => {
+          useIosSafariScrollFix({
+            isVisible: true,
+            containerRef,
+            iframeRef,
+          });
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIosSafariScrollFix.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useIosSafariScrollFix.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+interface UseIosSafariScrollFixOptions {
+  /** iframeが表示状態かどうか（プリロード→表示昇格の検知用） */
+  isVisible?: boolean;
+  /** 外側コンテナのRef（heightトグルによるリフロー用） */
+  containerRef: RefObject<HTMLDivElement | null>;
+  /** iframeのRef（width微小変更 + scrollTo用） */
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+}
+
+/**
+ * iOS Safari/Chrome: プリロード→表示昇格時のスクロール修正フック
+ *
+ * pointer-events-none + opacity-0 状態で読み込まれたiframeは、
+ * iOS WebKit でスクロール領域が正しく計算されない。
+ * 表示に切り替わったタイミングで以下を実施:
+ * 1. container の height トグルによるリフロー強制
+ * 2. iframe の width を微小変更→復元でレイアウト再計算
+ * 3. contentWindow の scrollTo(0,0) でスクロールエンジンの初期化
+ *
+ * さらに、表示昇格時のリフローだけではタイミングが合わないケースに備え、
+ * ユーザーが最初にタッチした瞬間にリフローを再実行する（once: true で1回のみ）。
+ */
+export function useIosSafariScrollFix(options: UseIosSafariScrollFixOptions): void {
+  const { isVisible, containerRef, iframeRef } = options;
+  const prevVisibleRef = useRef(false);
+
+  // Effect 1: 表示昇格時のリフロー強制
+  useEffect(() => {
+    if (isVisible && !prevVisibleRef.current) {
+      const container = containerRef.current;
+      const iframe = iframeRef.current;
+      if (container) {
+        container.style.height = "auto";
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            container.style.height = "";
+            if (iframe) {
+              iframe.style.width = "calc(100% - 1px)";
+              requestAnimationFrame(() => {
+                iframe.style.width = "";
+                try {
+                  iframe.contentWindow?.scrollTo(0, 0);
+                } catch {
+                  // cross-origin fallback
+                }
+              });
+            }
+          });
+        });
+      }
+    }
+    prevVisibleRef.current = !!isVisible;
+  }, [isVisible, containerRef, iframeRef]);
+
+  // Effect 2: 初回タッチ時のリフローフォールバック
+  useEffect(() => {
+    if (!isVisible) return;
+    const iframe = iframeRef.current;
+    const container = containerRef.current;
+    if (!iframe || !container) return;
+
+    let iframeWindow: Window | null = null;
+    try {
+      iframeWindow = iframe.contentWindow;
+    } catch {
+      return;
+    }
+    if (!iframeWindow) return;
+
+    const onFirstTouch = () => {
+      container.style.height = "auto";
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          container.style.height = "";
+        });
+      });
+    };
+
+    iframeWindow.addEventListener("touchstart", onFirstTouch, { once: true, passive: true });
+    return () => {
+      try {
+        iframeWindow.removeEventListener("touchstart", onFirstTouch);
+      } catch {
+        // iframe may have navigated away
+      }
+    };
+  }, [isVisible, containerRef, iframeRef]);
+}

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useNotFoundState.test.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useNotFoundState.test.ts
@@ -1,0 +1,207 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNotFoundState } from "./useNotFoundState";
+
+// use404Detectionのモック
+vi.mock("./use404Detection", () => ({
+  use404Detection: vi.fn(),
+}));
+
+import { use404Detection } from "./use404Detection";
+const mockUse404Detection = vi.mocked(use404Detection);
+
+describe("useNotFoundState", () => {
+  beforeEach(() => {
+    mockUse404Detection.mockReturnValue({
+      isChecking: false,
+      isNotFound: false,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }))
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("初期状態", () => {
+    it("showNotFoundがfalseで初期化される", () => {
+      const { result } = renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      expect(result.current.showNotFound).toBe(false);
+    });
+
+    it("handleSuggestが関数として返される", () => {
+      const { result } = renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      expect(typeof result.current.handleSuggest).toBe("function");
+    });
+  });
+
+  describe("URL変更時のリセット", () => {
+    it("URL変更時にshowNotFoundがfalseにリセットされる", async () => {
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      const { result, rerender } = renderHook(({ url }) => useNotFoundState({ url }), {
+        initialProps: { url: "https://example.com/1" },
+      });
+
+      // 404を検知してshowNotFound=trueにする
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+      expect(result.current.showNotFound).toBe(true);
+
+      // URL変更
+      rerender({ url: "https://example.com/2" });
+      expect(result.current.showNotFound).toBe(false);
+    });
+  });
+
+  describe("404検知", () => {
+    it("use404Detectionにurl/onNotFoundが渡される", () => {
+      renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      expect(mockUse404Detection).toHaveBeenCalledWith({
+        url: "https://example.com",
+        onNotFound: expect.any(Function),
+      });
+    });
+
+    it("onNotFound呼び出しでshowNotFoundがtrueになる", async () => {
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      const { result } = renderHook(() =>
+        useNotFoundState({ url: "https://example.com", articleId: "scp-173" })
+      );
+
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+
+      expect(result.current.showNotFound).toBe(true);
+    });
+
+    it("articleIdがある場合にDB更新APIが呼ばれる", async () => {
+      const mockFetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      renderHook(() => useNotFoundState({ url: "https://example.com", articleId: "scp-173" }));
+
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/articles/scp-173/translation", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ lang: "ja", hasTranslation: false }),
+      });
+    });
+
+    it("articleIdがない場合にDB更新APIが呼ばれない", async () => {
+      const mockFetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+      vi.stubGlobal("fetch", mockFetch);
+
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("DB更新APIが失敗してもshowNotFoundはtrueになる", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => Promise.reject(new Error("Network error")))
+      );
+
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      const { result } = renderHook(() =>
+        useNotFoundState({ url: "https://example.com", articleId: "scp-173" })
+      );
+
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+
+      expect(result.current.showNotFound).toBe(true);
+    });
+  });
+
+  describe("handleSuggest", () => {
+    it("handleSuggest呼び出しでshowNotFoundがfalseになる", async () => {
+      let capturedOnNotFound: (() => void | Promise<void>) | undefined;
+      mockUse404Detection.mockImplementation(({ onNotFound }) => {
+        capturedOnNotFound = onNotFound;
+        return { isChecking: false, isNotFound: false };
+      });
+
+      const { result } = renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      // まず404検知でshowNotFound=trueにする
+      await act(async () => {
+        await capturedOnNotFound?.();
+      });
+      expect(result.current.showNotFound).toBe(true);
+
+      // handleSuggestでfalseに戻る
+      act(() => {
+        result.current.handleSuggest();
+      });
+      expect(result.current.showNotFound).toBe(false);
+    });
+
+    it("handleSuggest呼び出しでonSkipコールバックが呼ばれる", () => {
+      const onSkip = vi.fn();
+      const { result } = renderHook(() => useNotFoundState({ url: "https://example.com", onSkip }));
+
+      act(() => {
+        result.current.handleSuggest();
+      });
+
+      expect(onSkip).toHaveBeenCalledTimes(1);
+    });
+
+    it("onSkipが未指定でもhandleSuggestがエラーにならない", () => {
+      const { result } = renderHook(() => useNotFoundState({ url: "https://example.com" }));
+
+      expect(() => {
+        act(() => {
+          result.current.handleSuggest();
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useNotFoundState.ts
+++ b/apps/web/src/app/(main)/recommend/_components/ArticleWebView/useNotFoundState.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { use404Detection } from "./use404Detection";
+
+interface UseNotFoundStateOptions {
+  /** チェック対象のURL */
+  url: string;
+  /** 記事ID（404検知時のDB更新に使用） */
+  articleId?: string;
+  /** 次の記事に遷移するコールバック */
+  onSkip?: () => void;
+}
+
+interface UseNotFoundStateReturn {
+  /** 翻訳なし（404）表示中かどうか */
+  showNotFound: boolean;
+  /** サジェスト画面から次の記事に遷移 */
+  handleSuggest: () => void;
+}
+
+/**
+ * 404検知とNotFound UI状態を管理するフック
+ *
+ * - use404Detection を内部で使用してURLの存在を確認
+ * - 404検知時にDB更新（翻訳なしフラグ設定）を実行
+ * - showNotFound 状態とサジェスト操作を提供
+ */
+export function useNotFoundState(options: UseNotFoundStateOptions): UseNotFoundStateReturn {
+  const { url, articleId, onSkip } = options;
+  const [showNotFound, setShowNotFound] = useState(false);
+
+  // URL変更時にリセット
+  useEffect(() => {
+    setShowNotFound(false);
+  }, [url]);
+
+  // 404検知時の処理
+  const handleNotFound = useCallback(async () => {
+    if (articleId) {
+      try {
+        await fetch(`/api/articles/${articleId}/translation`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lang: "ja", hasTranslation: false }),
+        });
+      } catch {
+        // API呼び出し失敗してもサジェスト画面は表示
+      }
+    }
+    setShowNotFound(true);
+  }, [articleId]);
+
+  // 404検知（バックグラウンドで実行）
+  use404Detection({
+    url,
+    onNotFound: handleNotFound,
+  });
+
+  // 次の記事に遷移
+  const handleSuggest = useCallback(() => {
+    setShowNotFound(false);
+    onSkip?.();
+  }, [onSkip]);
+
+  return { showNotFound, handleSuggest };
+}


### PR DESCRIPTION
ArticleWebView.tsx（325行→126行）のファットコンポーネントを
SOLID原則に基づき3つのカスタムフックに分離:

- useIosSafariScrollFix: iOS Safari プリロード→表示昇格時のスクロール修正
- useNotFoundState: 404検知とNotFound UI状態管理
- useIframeLoadHandler: iframeロード後のコンテンツ取得ライフサイクル

TDDで各フックのテストを先行作成し、全99テスト通過を確認。

https://claude.ai/code/session_019qr97tBrMYmLFi6ppX7rQf