### PR TITLE
fix(skeleton): 記事スケルトンの高さを画面下部付近まで拡張

### DIFF
--- a/apps/web/src/shared/components/ui/SkeletonLoader/index.tsx
+++ b/apps/web/src/shared/components/ui/SkeletonLoader/index.tsx
@@ -15,12 +15,12 @@ export function SkeletonLoader() {
   return (
     <div data-testid="skeleton-loader" className="flex h-screen w-full flex-col">
       {/* 記事エリアのスケルトン */}
-      <div className="flex-1 animate-pulse overflow-hidden bg-gray-100 px-6 pt-6 pb-6">
+      <div className="flex min-h-0 flex-1 animate-pulse flex-col bg-gray-100 px-6 pt-6 pb-6">
         {/* タイトル */}
-        <div className="mb-6 h-8 w-48 rounded bg-gray-200" />
+        <div className="mb-6 h-8 w-48 shrink-0 rounded bg-gray-200" />
 
         {/* 本文行 */}
-        <div className="space-y-3">
+        <div className="min-h-0 flex-1 space-y-3 overflow-hidden">
           {/* 段落1 */}
           <SkeletonLine width="w-full" />
           <SkeletonLine width="w-11/12" />


### PR DESCRIPTION
スケルトンUIの本文プレースホルダー行を5段落（21行）に増やし、
画面全体に近い高さまで表示されるよう改善。
ピルナビゲーションとの重なりを防ぐためpb-28を追加し、
overflow-hiddenで余剰コンテンツをクリップ。

https://claude.ai/code/session_01EBBSeiR1jdtbUz7QsiPRJ7