### PR TITLE
fix(pwa): ステータスバーの背景色を白に変更

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#FFFFFF",
-  "theme_color": "#3B82F6",
+  "theme_color": "#FFFFFF",
   "orientation": "portrait",
   "lang": "ja",
   "icons": [

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "SCPicks - あなた好みのSCPを発見",
   description: "あなたの好みに合ったSCP記事を推薦するWebアプリ",
   manifest: "/manifest.json",
+  themeColor: "#FFFFFF",
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",


### PR DESCRIPTION
theme_colorを#3B82F6(青)から#FFFFFF(白)に変更。
アプリの白背景とステータスバーの視覚的一体感を確保し、
一般的なアプリのデザイン傾向に合わせた。

変更箇所:
- manifest.json: theme_color を #FFFFFF に変更
- layout.tsx: themeColor メタタグを追加

https://claude.ai/code/session_01V77fHvJVGxzCASBZdHpHwT