### PR TITLE
fix(migration): CHECK制約の削除をUPDATEの前に移動

### DIFF
--- a/supabase/migrations/20260223000001_feedback_metadata_and_rename.sql
+++ b/supabase/migrations/20260223000001_feedback_metadata_and_rename.sql
@@ -11,11 +11,11 @@ ALTER TABLE feedback ADD COLUMN IF NOT EXISTS metadata JSONB;
 
 COMMENT ON COLUMN feedback.metadata IS 'フィードバックメタデータ（scrollDepth, dwellTime, interestLevel）';
 
--- 2. skip → next にリネーム
-UPDATE feedback SET type = 'next' WHERE type = 'skip';
-
--- 3. 既存のCHECK制約を削除
+-- 2. 既存のCHECK制約を削除（UPDATEの前に削除しないと制約違反になる）
 ALTER TABLE feedback DROP CONSTRAINT IF EXISTS feedback_type_check;
+
+-- 3. skip → next にリネーム
+UPDATE feedback SET type = 'next' WHERE type = 'skip';
 
 -- 4. 新しいCHECK制約（dislike除去 + next追加）
 ALTER TABLE feedback ADD CONSTRAINT feedback_type_check CHECK (type IN ('like', 'next'));


### PR DESCRIPTION
既存のCHECK制約がskip→nextのUPDATE前に存在するため
制約違反(SQLSTATE 23514)でmigrationが失敗していた。
DROP CONSTRAINTをUPDATEの前に移動して解消。

https://claude.ai/code/session_019Zna9p9cn7pALN67oANget