### PR TITLE
fix(api-server): ローカル開発サーバーのSupabaseクライアントをservice_role keyに修正

### DIFF
--- a/.ai/architecture.md
+++ b/.ai/architecture.md
@@ -27,7 +27,7 @@ recommend-scpは、SCP Foundation記事の推薦システム。
 | APIサーバー       | Hono (独立サーバー)              | 高性能、RPC型共有、フロントエンド分離     |
 | Webフレームワーク | Next.js App Router               | Server Components、静的最適化             |
 | モノレポ          | Turborepo                        | 高速ビルド、キャッシュ                    |
-| ホスティング      | Vercel (Web) / Railway (API)     | 分離デプロイ、スケール独立                |
+| ホスティング      | Vercel (Web + API)               | 統合デプロイ、Next.js API Routes経由      |
 
 ---
 
@@ -332,30 +332,37 @@ logger.error({ err, visitorId }, "推薦計算エラー");
 ## デプロイ構成
 
 ```
-┌─────────────────┐     ┌─────────────────┐
-│   Vercel        │     │   Railway       │
-│   (Next.js)     │────▶│   (Hono API)    │
-│   apps/web      │     │   apps/api-server│
-└─────────────────┘     └────────┬────────┘
-                                 │
-                        ┌────────▼────────┐
-                        │   Supabase      │
-                        │   (PostgreSQL   │
-                        │    + pgvector)  │
-                        └─────────────────┘
+┌──────────────────────────────┐
+│         Vercel               │
+│  ┌────────────────────────┐  │
+│  │  Next.js (apps/web)    │  │
+│  │  ├── App Router (SSR)  │  │
+│  │  └── API Routes        │  │
+│  │      /api/[...route]   │──┼──▶ Hono API (apps/api-server)
+│  └────────────────────────┘  │     をNext.js API Routes経由で提供
+└──────────────┬───────────────┘
+               │
+      ┌────────▼────────┐
+      │   Supabase      │
+      │   (PostgreSQL   │
+      │    + pgvector)  │
+      └─────────────────┘
 ```
+
+**Note:** `apps/api-server` はローカル開発用のスタンドアロンサーバーとしても動作。
+本番環境では `apps/web/src/app/api/[...route]/route.ts` 経由で提供。
 
 ### 環境変数
 
 ```bash
-# API Server (Railway)
-DATABASE_URL=postgresql://...
+# Vercel (本番) - Web + API 統合
 SUPABASE_URL=https://xxx.supabase.co
-SUPABASE_ANON_KEY=xxx
-OPENAI_API_KEY=xxx  # Embedding用
+SUPABASE_SERVICE_ROLE_KEY=xxx  # サーバーサイドDB操作用
+SUPABASE_ANON_KEY=xxx          # クライアントサイド用（将来）
+OPENAI_API_KEY=xxx             # Embedding用
 
-# Web (Vercel)
-NEXT_PUBLIC_API_URL=https://api.recommend-scp.dev
+# ローカル開発 (apps/api-server スタンドアロン)
+# .env で同じ変数を設定
 ```
 
 ---

--- a/apps/api-server/src/__dev__/app.test.ts
+++ b/apps/api-server/src/__dev__/app.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
 // Supabaseクライアントをモック
 vi.mock("@recommend-scp/shared/lib/supabase", () => ({
-  getSupabaseClient: vi.fn(),
+  getSupabaseAdmin: vi.fn(),
 }));
 
-import { getSupabaseClient } from "@recommend-scp/shared/lib/supabase";
+import { getSupabaseAdmin } from "@recommend-scp/shared/lib/supabase";
 import { createApp, createRoutes } from "../app";
 import type { AppType } from "../app";
 
@@ -25,10 +25,10 @@ describe("Honoアプリケーション", () => {
         }),
       }),
     };
-    (getSupabaseClient as Mock).mockReturnValue(mockClient);
+    (getSupabaseAdmin as Mock).mockReturnValue(mockClient);
 
     // テスト用にアプリケーションを作成
-    app = createApp(getSupabaseClient());
+    app = createApp(getSupabaseAdmin());
   });
 
   it("Hono インスタンスが export される", () => {
@@ -37,7 +37,7 @@ describe("Honoアプリケーション", () => {
   });
 
   it("AppType 型が export される", () => {
-    const routes = createRoutes(getSupabaseClient());
+    const routes = createRoutes(getSupabaseAdmin());
     const _typeCheck: AppType = routes;
     expect(_typeCheck).toBeDefined();
   });

--- a/apps/api-server/src/index.ts
+++ b/apps/api-server/src/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 import { env } from "@recommend-scp/shared/lib/env";
-import { getSupabaseClient } from "@recommend-scp/shared/lib/supabase";
+import { getSupabaseAdmin } from "@recommend-scp/shared/lib/supabase";
 import { pino } from "pino";
 import { createApp } from "./app";
 
@@ -12,7 +12,7 @@ const port = env.API_PORT;
 
 logger.info({ port }, "APIサーバーを起動します");
 
-const supabase = getSupabaseClient();
+const supabase = getSupabaseAdmin();
 const app = createApp(supabase);
 
 serve({

--- a/apps/api-server/src/routes/__dev__/health.test.ts
+++ b/apps/api-server/src/routes/__dev__/health.test.ts
@@ -3,10 +3,10 @@ import { Hono } from "hono";
 
 // Supabaseクライアントをモック
 vi.mock("@recommend-scp/shared/lib/supabase", () => ({
-  getSupabaseClient: vi.fn(),
+  getSupabaseAdmin: vi.fn(),
 }));
 
-import { getSupabaseClient } from "@recommend-scp/shared/lib/supabase";
+import { getSupabaseAdmin } from "@recommend-scp/shared/lib/supabase";
 import { healthRoutes } from "../health";
 
 // パッケージバージョン
@@ -40,7 +40,7 @@ const setupMockClient = (success: boolean) => {
       }),
     }),
   };
-  (getSupabaseClient as Mock).mockReturnValue(mockClient);
+  (getSupabaseAdmin as Mock).mockReturnValue(mockClient);
   return mockClient;
 };
 
@@ -150,7 +150,7 @@ describe("GET /health - 異常系（DB接続失敗）", () => {
         }),
       }),
     };
-    (getSupabaseClient as Mock).mockReturnValue(mockClient);
+    (getSupabaseAdmin as Mock).mockReturnValue(mockClient);
 
     const app = createApp();
     const req = new Request("http://localhost/health");

--- a/apps/api-server/src/routes/health.ts
+++ b/apps/api-server/src/routes/health.ts
@@ -8,7 +8,7 @@
  */
 
 import { Hono } from "hono";
-import { getSupabaseClient } from "@recommend-scp/shared/lib/supabase";
+import { getSupabaseAdmin } from "@recommend-scp/shared/lib/supabase";
 import { logger } from "../lib/logger";
 
 // パッケージバージョンを取得
@@ -38,7 +38,7 @@ export const healthRoutes = new Hono().get("/", async (c) => {
 
   // DB接続チェック
   try {
-    const supabase = getSupabaseClient();
+    const supabase = getSupabaseAdmin();
     const { error } = await supabase.from("scp_articles").select("id").limit(1);
 
     if (error) {


### PR DESCRIPTION
ローカル開発用のapi-serverがgetSupabaseClient(anon key)を使用していたため、
RLSポリシーによりfeedback等のテーブルへの書き込みが500エラーとなっていた。
本番(Vercel)のroute.tsは既にSUPABASE_SERVICE_ROLE_KEYを使用しており正常。

- index.ts: getSupabaseClient → getSupabaseAdmin に変更
- health.ts: 同上（一貫性のため）
- テストファイル: モック名を合わせて更新
- architecture.md: デプロイ構成をRailway→Vercel統合に修正

https://claude.ai/code/session_018jsbGJnosGxwmndgqVQsdi