### PR TITLE
Fix feedback table: remove dislike rows and reapply CHECK constraint

### DIFF
--- a/supabase/migrations/20260228000001_fix_feedback_dislike_rows.sql
+++ b/supabase/migrations/20260228000001_fix_feedback_dislike_rows.sql
@@ -1,0 +1,17 @@
+-- ============================================
+-- feedbackテーブル: dislike行の削除 + CHECK制約の再適用
+-- ============================================
+-- 前回マイグレーション(20260223000001)がCI環境で失敗:
+--   本番DBに type='dislike' の行が存在し、CHECK制約と衝突
+--   ERROR: check constraint "feedback_type_check" is violated by some row
+-- UIにDislikeボタンは存在せず不要データのため削除で対応
+-- ============================================
+
+-- 1. dislike行を削除（UIに存在しないため不要データ）
+DELETE FROM feedback WHERE type = 'dislike';
+
+-- 2. 前回マイグレーションが途中失敗した場合に備え制約を一旦削除
+ALTER TABLE feedback DROP CONSTRAINT IF EXISTS feedback_type_check;
+
+-- 3. CHECK制約を再適用
+ALTER TABLE feedback ADD CONSTRAINT feedback_type_check CHECK (type IN ('like', 'next'));


### PR DESCRIPTION
## Summary
This migration fixes a data integrity issue in the `feedback` table by removing obsolete `dislike` type entries and reapplying the CHECK constraint that was previously blocked by incompatible data.

## Changes
- **Delete dislike records**: Removes all rows where `type = 'dislike'` since the UI no longer supports a dislike button
- **Reapply CHECK constraint**: Safely removes and recreates the `feedback_type_check` constraint to enforce only valid types (`like` and `next`)

## Context
The previous migration (20260223000001) failed in production because existing `dislike` rows violated the new CHECK constraint. This migration resolves that conflict by:
1. Cleaning up the obsolete data
2. Handling cases where the constraint may have been partially applied
3. Ensuring the constraint is properly enforced going forward

https://claude.ai/code/session_01JamAX2Dgha4Kfd7tnoR39w