### PR TITLE
Fix E2E test mocking and improve CI artifact handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           name: playwright-report
           path: apps/web/playwright-report/
           retention-days: 7
+          if-no-files-found: warn
 
       - name: Upload Test Results (Traces)
         uses: actions/upload-artifact@v4
@@ -174,6 +175,7 @@ jobs:
           name: playwright-test-results
           path: apps/web/e2e/test-results/
           retention-days: 7
+          if-no-files-found: warn
 
       - name: E2E Skipped Notice
         if: steps.e2e_target.outputs.skip == 'true'

--- a/apps/web/e2e/lib/setup.ts
+++ b/apps/web/e2e/lib/setup.ts
@@ -58,6 +58,12 @@ export async function setupRecommendMock(page: Page): Promise<void> {
  */
 export async function setupFavoritesMock(page: Page): Promise<void> {
   await page.route("**/favorites**", async (route) => {
+    // ページナビゲーション（HTML取得）はインターセプトしない
+    if (route.request().resourceType() === "document") {
+      await route.continue();
+      return;
+    }
+
     if (route.request().method() === "GET") {
       await route.fulfill({
         status: 200,

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -5,6 +5,7 @@ const isRemote = !!process.env.PLAYWRIGHT_BASE_URL;
 
 export default defineConfig({
   testDir: "./specs",
+  outputDir: "./test-results",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Summary
This PR improves the E2E test setup and CI/CD pipeline by fixing an issue with the favorites mock interceptor and enhancing artifact upload handling.

## Key Changes
- **Fixed favorites mock interceptor**: Added a check to skip intercepting document-type requests (HTML page navigation) in the `setupFavoritesMock` function. This prevents the mock from interfering with actual page navigation while still mocking API requests.
- **Configured Playwright output directory**: Explicitly set `outputDir` to `./test-results` in the Playwright config to ensure test results are properly organized.
- **Improved CI artifact uploads**: Added `if-no-files-found: warn` to both playwright-report and test-results artifact uploads in the CI workflow. This prevents job failures when artifacts don't exist while still providing visibility through warnings.

## Implementation Details
The favorites mock now checks the request resource type and allows document requests to pass through unintercepted, ensuring that page navigation works correctly while API mocking continues to function as expected.

https://claude.ai/code/session_01CGiBCdyw2ja9CtqSZzvPSq