### PR TITLE
fix(recommend): お気に入り済み記事でfeedback APIへのnext送信をスキップ

### DIFF
--- a/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
+++ b/apps/web/src/app/(main)/recommend/__tests__/page.test.tsx
@@ -732,6 +732,17 @@ describe("RecommendPage 統合テスト (006-05-07)", () => {
       expect(mockUseArticleFavoriteResult.toggleFavorite).toHaveBeenCalled();
     });
 
+    it("お気に入りボタンタップでrecordFavoriteが呼ばれる", async () => {
+      setupDefaultArticles();
+      render(<RecommendPage />);
+      dismissInitialCard();
+
+      const favoriteButton = await screen.findByLabelText("お気に入りに追加");
+      await userEvent.click(favoriteButton);
+
+      expect(mockUseFeedbackResult.recordFavorite).toHaveBeenCalledWith("scp-173");
+    });
+
     it("お気に入りボタンタップ後も遷移フローに影響しない", async () => {
       setupDefaultArticles();
       render(<RecommendPage />);

--- a/apps/web/src/app/(main)/recommend/page.tsx
+++ b/apps/web/src/app/(main)/recommend/page.tsx
@@ -44,7 +44,7 @@ export default function RecommendPage() {
   const { articles, currentIndex, isLoading, error, isEmpty, goToNext, refetch } =
     useInfiniteArticles();
 
-  const { recordNext } = useFeedback();
+  const { recordNext, recordFavorite } = useFeedback();
   const currentArticle = articles[currentIndex] as (typeof articles)[number] | undefined;
   const { isFavorited, toggleFavorite } = useArticleFavorite({
     articleId: currentArticle?.id,
@@ -186,7 +186,10 @@ export default function RecommendPage() {
   // NOTE: recordLikeは廃止。お気に入りはfavorites APIのみで管理（重み2.0）
   const handleFavorite = useCallback(() => {
     void toggleFavorite();
-  }, [toggleFavorite]);
+    if (currentArticle?.id) {
+      void recordFavorite(currentArticle.id);
+    }
+  }, [toggleFavorite, recordFavorite, currentArticle?.id]);
 
   // コンテンツ読み込み完了ハンドラー（履歴保存）
   const handleContentLoaded = useCallback(


### PR DESCRIPTION
handleFavoriteでrecordFavoriteを呼び出し、useFeedbackの優先度システム （favorite=2 > next=1）を活性化。お気に入り後の「次へ」タップで
不要なPOST /feedbackが送信されなくなる。

https://claude.ai/code/session_01T8QxdAshwJxdpZgqfsSAWC