### PR TITLE
Add blob reporting and merge E2E test reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,16 +148,22 @@ jobs:
       # --- E2E実行（リモートURLが取得できた場合のみ） ---
       - name: Run Critical E2E Tests
         if: steps.e2e_target.outputs.skip != 'true'
-        run: pnpm --filter web test:e2e --grep @critical
+        run: pnpm --filter web test:e2e --grep @critical --reporter=list,blob
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.e2e_target.outputs.url }}
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/critical
 
       - name: Run Non-Critical E2E Tests
         if: steps.e2e_target.outputs.skip != 'true'
-        run: pnpm --filter web test:e2e --grep-invert @critical
+        run: pnpm --filter web test:e2e --grep-invert @critical --reporter=list,blob
         continue-on-error: true
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.e2e_target.outputs.url }}
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/non-critical
+
+      - name: Merge E2E Reports
+        if: always() && steps.e2e_target.outputs.skip != 'true'
+        run: pnpm --filter web exec playwright merge-reports --reporter=html ./blob-report
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Enhanced E2E test reporting by adding Playwright blob reporter output and implementing a report merge step to consolidate critical and non-critical test results.

## Key Changes
- Added `--reporter=list,blob` flag to both critical and non-critical E2E test commands to generate blob reports alongside list output
- Configured separate blob report output directories for critical (`blob-report/critical`) and non-critical (`blob-report/non-critical`) tests via `PLAYWRIGHT_BLOB_OUTPUT_DIR` environment variable
- Added new "Merge E2E Reports" step that runs after all E2E tests (using `if: always()`) to consolidate blob reports into a single HTML report using `playwright merge-reports`

## Implementation Details
- The merge step uses `--reporter=html` to generate a unified HTML report from the individual blob reports
- The merge step is conditional on both `always()` (to run regardless of test results) and the E2E target check to avoid running when E2E tests are skipped
- This approach allows tests to run in parallel while maintaining separate reports that can be merged for a comprehensive view

https://claude.ai/code/session_01EtNhXeTvSy9d3ddGkCUGxM