### PR TITLE
fix(ci): E2Eレポートマージ時のblob未存在エラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,12 @@ jobs:
 
       - name: Merge E2E Reports
         if: always() && steps.e2e_target.outputs.skip != 'true'
-        run: pnpm --filter web exec playwright merge-reports --reporter=html ./blob-report
+        run: |
+          if find apps/web/blob-report -name '*.zip' 2>/dev/null | grep -q .; then
+            pnpm --filter web exec playwright merge-reports --reporter=html ./blob-report
+          else
+            echo "::warning::No blob report files found, skipping merge"
+          fi
 
       - name: Upload Playwright Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
merge-reportsステップがalways()で実行されるため、テスト実行が
失敗してblobファイルが生成されていない場合にエラーになっていた。
blob .zipファイルの存在を事前チェックし、なければwarningで
スキップするように修正。

https://claude.ai/code/session_01SKU6BWLu8nNPQy1jCNX9Ec