### PR TITLE
Simplify E2E test blob report output directory configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         run: pnpm --filter web test:e2e --grep @critical --reporter=list,blob
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.e2e_target.outputs.url }}
-          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/critical
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report
 
       - name: Run Non-Critical E2E Tests
         if: steps.e2e_target.outputs.skip != 'true'
@@ -159,7 +159,7 @@ jobs:
         continue-on-error: true
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.e2e_target.outputs.url }}
-          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/non-critical
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report
 
       - name: Merge E2E Reports
         if: always() && steps.e2e_target.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
Unified the blob report output directory for both critical and non-critical E2E tests to use a single `blob-report` directory instead of separate subdirectories.

## Changes
- Changed `PLAYWRIGHT_BLOB_OUTPUT_DIR` for critical E2E tests from `blob-report/critical` to `blob-report`
- Changed `PLAYWRIGHT_BLOB_OUTPUT_DIR` for non-critical E2E tests from `blob-report/non-critical` to `blob-report`

## Details
This simplification consolidates the E2E test blob report output into a single directory. The existing "Merge E2E Reports" step should handle combining reports from both test runs, making the separate subdirectories unnecessary.

https://claude.ai/code/session_018bHQX7whDiGJpjWqkm3jDd