### PR TITLE
Add onboarding flow E2E tests with mock setup

### DIFF
--- a/apps/web/e2e/lib/mock-data.ts
+++ b/apps/web/e2e/lib/mock-data.ts
@@ -90,6 +90,63 @@ export const mockHistoryEntries = [
   },
 ];
 
+/** モック: POST /visitors レスポンス（新規ビジター、オンボーディング未完了） */
+export const mockVisitorNew = {
+  visitorId: "e2e-test-visitor-001",
+  isNew: true,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  onboardingCompletedAt: null,
+};
+
+/** モック: GET /onboarding/packs レスポンス */
+export const mockOnboardingPacksResponse = {
+  packs: [
+    {
+      type: "classic",
+      displayName: "クラシック",
+      description: "SCP定番の名作集",
+      primaryTags: ["classic"],
+    },
+    {
+      type: "horror",
+      displayName: "ホラー",
+      description: "恐怖と不安を呼ぶSCP",
+      primaryTags: ["horror"],
+    },
+    {
+      type: "scifi",
+      displayName: "SF",
+      description: "科学とSFのSCP",
+      primaryTags: ["scifi"],
+    },
+    {
+      type: "heartwarming",
+      displayName: "ほっこり",
+      description: "心温まるSCP",
+      primaryTags: ["heartwarming"],
+    },
+    {
+      type: "mystery",
+      displayName: "ミステリー",
+      description: "謎と推理のSCP",
+      primaryTags: ["mystery"],
+    },
+    {
+      type: "jp",
+      displayName: "日本支部",
+      description: "SCP-JP作品集",
+      primaryTags: ["jp"],
+    },
+  ],
+};
+
+/** モック: POST /onboarding/select レスポンス */
+export const mockOnboardingSelectResponse = {
+  success: true,
+  visitorId: "e2e-test-visitor-001",
+  selectedPacks: ["horror"],
+};
+
 /** localStorageキー定義 */
 export const STORAGE_KEYS = {
   visitorId: "recommend_scp_visitor_id",

--- a/apps/web/e2e/lib/setup.ts
+++ b/apps/web/e2e/lib/setup.ts
@@ -6,9 +6,12 @@
 import type { Page } from "@playwright/test";
 import {
   mockVisitorOnboarded,
+  mockVisitorNew,
   mockRecommendResponse,
   mockFavoritesResponse,
   mockHistoryEntries,
+  mockOnboardingPacksResponse,
+  mockOnboardingSelectResponse,
   STORAGE_KEYS,
 } from "./mock-data";
 
@@ -24,6 +27,25 @@ export async function setupOnboardedVisitor(page: Page): Promise<void> {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(mockVisitorOnboarded),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * 新規ビジターのAPIモックを設定（オンボーディング未完了）
+ *
+ * POST /visitors → オンボーディング未完了のレスポンスを返す
+ */
+export async function setupNewVisitor(page: Page): Promise<void> {
+  await page.route("**/visitors", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockVisitorNew),
       });
     } else {
       await route.continue();
@@ -95,6 +117,44 @@ export async function setupFeedbackMock(page: Page): Promise<void> {
 }
 
 /**
+ * オンボーディングパック一覧APIのモックを設定
+ *
+ * GET /onboarding/packs → テスト用パックデータを返す
+ */
+export async function setupOnboardingPacksMock(page: Page): Promise<void> {
+  await page.route("**/onboarding/packs", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockOnboardingPacksResponse),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
+ * オンボーディング選択確定APIのモックを設定
+ *
+ * POST /onboarding/select → 成功レスポンスを返す
+ */
+export async function setupOnboardingSelectMock(page: Page): Promise<void> {
+  await page.route("**/onboarding/select", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(mockOnboardingSelectResponse),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+}
+
+/**
  * 閲覧履歴のlocalStorageをシードする
  */
 export async function seedHistory(page: Page): Promise<void> {
@@ -124,12 +184,28 @@ export async function seedOnboardingCompleted(page: Page): Promise<void> {
 }
 
 /**
+ * visitorIdのみをlocalStorageにシードする（オンボーディング完了フラグはセットしない）
+ */
+export async function seedVisitorId(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ visitorIdKey, visitorId }) => {
+      localStorage.setItem(visitorIdKey, visitorId);
+    },
+    {
+      visitorIdKey: STORAGE_KEYS.visitorId,
+      visitorId: mockVisitorNew.visitorId,
+    }
+  );
+}
+
+/**
  * 推薦画面テスト用のフルセットアップ
  */
 export async function setupRecommendTest(page: Page): Promise<void> {
   await setupOnboardedVisitor(page);
   await setupRecommendMock(page);
   await setupFeedbackMock(page);
+  await setupFavoritesMock(page);
   await seedOnboardingCompleted(page);
 }
 
@@ -149,4 +225,16 @@ export async function setupHistoryTest(page: Page): Promise<void> {
   await setupOnboardedVisitor(page);
   await seedOnboardingCompleted(page);
   await seedHistory(page);
+}
+
+/**
+ * オンボーディング画面テスト用のフルセットアップ
+ *
+ * 新規ビジター（オンボーディング未完了）のAPIモックとlocalStorageを設定
+ */
+export async function setupOnboardingTest(page: Page): Promise<void> {
+  await setupNewVisitor(page);
+  await setupOnboardingPacksMock(page);
+  await setupOnboardingSelectMock(page);
+  await seedVisitorId(page);
 }

--- a/apps/web/e2e/lib/testcases/favorites.csv
+++ b/apps/web/e2e/lib/testcases/favorites.csv
@@ -1,4 +1,4 @@
 id,name,steps,expected,tags,result
-TC-006-03-001,お気に入り一覧表示,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorites-page"",""timeout"":3000},{""action"":""assertVisible"",""testId"":""favorite-list""}]",お気に入り一覧が表示される,critical,
-TC-006-03-002,お気に入りカード内容表示,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorite-card"",""timeout"":3000},{""action"":""assertVisible"",""testId"":""favorite-card""}]",記事タイトルとオブジェクトクラスが表示される,critical,
-TC-006-03-003,お気に入り記事詳細遷移,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorite-card"",""timeout"":3000},{""action"":""click"",""testId"":""favorite-card""},{""action"":""assertUrl"",""pattern"":""/article/""}]",記事詳細画面に遷移する,critical,
+TC-006-03-001,お気に入り一覧表示,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorites-page"",""timeout"":5000},{""action"":""assertVisible"",""testId"":""favorite-list""}]",お気に入り一覧が表示される,critical,
+TC-006-03-002,お気に入りカード内容表示,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorite-card"",""timeout"":5000},{""action"":""assertVisible"",""testId"":""favorite-card""}]",記事タイトルとオブジェクトクラスが表示される,critical,
+TC-006-03-003,お気に入り記事詳細遷移,"[{""action"":""goto"",""url"":""/favorites""},{""action"":""waitFor"",""testId"":""favorite-card"",""timeout"":5000},{""action"":""click"",""testId"":""favorite-card""},{""action"":""assertUrl"",""pattern"":""/article/""}]",記事詳細画面に遷移する,critical,

--- a/apps/web/e2e/lib/testcases/history.csv
+++ b/apps/web/e2e/lib/testcases/history.csv
@@ -1,4 +1,4 @@
 id,name,steps,expected,tags,result
-TC-006-04-001,閲覧履歴一覧表示,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":3000},{""action"":""assertVisible"",""testId"":""history-card""}]",閲覧履歴一覧が表示される,critical,
-TC-006-04-002,履歴カード情報表示,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":3000},{""action"":""assertVisible"",""testId"":""history-card""}]",SCP番号・オブジェクトクラスが表示される,critical,
-TC-006-04-003,履歴カードから記事詳細遷移,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":3000},{""action"":""click"",""testId"":""history-card""},{""action"":""assertUrl"",""pattern"":""/article/""}]",記事詳細画面に遷移する,critical,
+TC-006-04-001,閲覧履歴一覧表示,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":5000},{""action"":""assertVisible"",""testId"":""history-card""}]",閲覧履歴一覧が表示される,critical,
+TC-006-04-002,履歴カード情報表示,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":5000},{""action"":""assertVisible"",""testId"":""history-card""}]",SCP番号・オブジェクトクラスが表示される,critical,
+TC-006-04-003,履歴カードから記事詳細遷移,"[{""action"":""goto"",""url"":""/history""},{""action"":""waitFor"",""testId"":""history-card"",""timeout"":5000},{""action"":""click"",""testId"":""history-card""},{""action"":""assertUrl"",""pattern"":""/article/""}]",記事詳細画面に遷移する,critical,

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   use: {
     baseURL,
     trace: "on-first-retry",
+    // E2Eテスト時はService Workerを無効化
+    // 本番デプロイのWorkbox SWがpage.route()モックと干渉するのを防止
+    serviceWorkers: "block",
   },
   projects: [
     {

--- a/apps/web/e2e/specs/onboarding.spec.ts
+++ b/apps/web/e2e/specs/onboarding.spec.ts
@@ -3,11 +3,16 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "node:url";
 import { parseTestCaseCsv } from "../lib/csv-parser";
 import { executeSteps } from "../lib/step-executor";
+import { setupOnboardingTest } from "../lib/setup";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const testCases = parseTestCaseCsv(join(__dirname, "../lib/testcases/onboarding.csv"));
 
 test.describe("オンボーディング画面", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOnboardingTest(page);
+  });
+
   for (const tc of testCases) {
     test(`${tc.name} @${tc.tags.join(" @")}`, async ({ page }) => {
       await executeSteps(page, tc.steps);


### PR DESCRIPTION
## Summary
This PR adds comprehensive E2E test infrastructure for the onboarding flow, including new mock data, setup utilities, and test case configurations.

## Key Changes

### Mock Data & Setup (`mock-data.ts` & `setup.ts`)
- Added `mockVisitorNew` for new visitor responses (onboarding incomplete state)
- Added `mockOnboardingPacksResponse` with 6 content pack options (classic, horror, scifi, heartwarming, mystery, jp)
- Added `mockOnboardingSelectResponse` for onboarding selection confirmation
- Implemented `setupNewVisitor()` to mock POST /visitors endpoint for new visitors
- Implemented `setupOnboardingPacksMock()` to mock GET /onboarding/packs endpoint
- Implemented `setupOnboardingSelectMock()` to mock POST /onboarding/select endpoint
- Implemented `seedVisitorId()` to set only visitorId in localStorage (without onboarding completion flag)
- Added `setupOnboardingTest()` composite setup function for onboarding test scenarios
- Enhanced `setupRecommendTest()` to include favorites mock setup

### Test Configuration
- Updated `onboarding.spec.ts` to use `setupOnboardingTest()` in beforeEach hook
- Increased timeout values in `favorites.csv` and `history.csv` test cases from 3000ms to 5000ms for better reliability
- Added Service Worker blocking in `playwright.config.ts` to prevent Workbox interference with page.route() mocks

## Implementation Details
- All onboarding mocks follow the existing pattern of checking HTTP method before fulfilling responses
- Mock data includes realistic SCP content pack descriptions in Japanese
- The `seedVisitorId()` function allows testing the onboarding flow for new visitors without pre-existing completion state
- Service Worker blocking is a critical fix to ensure mock routes work correctly in production-like environments

https://claude.ai/code/session_014HoMwXWkoTcqGWvcAnjk98