### PR TITLE
fix(web): themeColor を白 #FFFFFF に戻す

### DIFF
--- a/apps/web/src/app/__dev__/splash.test.ts
+++ b/apps/web/src/app/__dev__/splash.test.ts
@@ -134,8 +134,8 @@ describe("PWAスプラッシュスクリーン", () => {
   });
 
   describe("AC-3: スプラッシュスクリーンのデザイン統一性", () => {
-    it("layout.tsx の themeColor がブランドカラー #3B82F6 に更新されている", () => {
-      expect(layoutContent).toMatch(/themeColor\s*:\s*["']#3B82F6["']/);
+    it("layout.tsx の themeColor が白 #FFFFFF に設定されている", () => {
+      expect(layoutContent).toMatch(/themeColor\s*:\s*["']#FFFFFF["']/);
     });
 
     it("スプラッシュ画像生成スクリプトがブランドカラー #3B82F6 を参照している", () => {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -80,7 +80,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#3B82F6",
+  themeColor: "#FFFFFF",
 };
 
 /** JSON-LD: WebSite + WebApplication 構造化データ */


### PR DESCRIPTION
layout.tsx の viewport.themeColor が #3B82F6（青）に設定されており ステータスバーが青色で表示されていた。#FFFFFF に変更して白に戻す。

https://claude.ai/code/session_01X7MYNAc7NbZdpUoeWxsuE5