### PR TITLE
Mark E2E test completion in release checklist

### DIFF
--- a/specs/018-release-checklist/story-list.md
+++ b/specs/018-release-checklist/story-list.md
@@ -3,7 +3,7 @@
 | Story ID | Story名                | ステータス | 備考                       |
 | -------- | ---------------------- | ---------- | -------------------------- |
 | 018-01   | ライセンス準拠最終確認 | completed  | CC BY-SA 3.0準拠の本番確認 |
-| 018-02   | E2Eテスト全通過確認    | pending    | Playwright全spec実行       |
+| 018-02   | E2Eテスト全通過確認    | completed  | Playwright全spec実行       |
 | 018-03   | 本番パフォーマンス確認 | pending    | API応答・スロークエリ確認  |
 | 018-04   | OGP・SNS共有確認       | completed  | Twitterカード検証          |
 | 018-05   | アプリ文言統一         | completed  | 「発見」→「推薦」変更      |


### PR DESCRIPTION
## Summary
Update the release checklist to reflect the completion of E2E testing for the 018 release.

## Changes
- Mark story 018-02 (E2Eテスト全通過確認) status as `completed`
  - All Playwright specifications have been successfully executed
  - Previous status was `pending`

## Notes
This is part of the release preparation process for version 018. The E2E test suite validation is now complete, allowing the release to progress to the next verification steps.

https://claude.ai/code/session_01XbZmQAomdjd6qN5Aa2wv4T