### PR TITLE
Implement three-column layout for desktop and refactor page structure

### DIFF
--- a/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
+++ b/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
@@ -284,23 +284,24 @@ describe("FavoritesPage", () => {
   });
 
   describe("AC-PC-1: コンテンツ中央寄せ（PC版レイアウト）", () => {
-    it("お気に入りリストのラッパーにmd:max-w-[768px]が適用される", () => {
+    it("中央カラムにmd:max-w-[768px]とmd:shrink-0が適用される", () => {
       render(<FavoritesPage />);
 
       const page = screen.getByTestId("favorites-page");
-      const mainEl = page.querySelector("main");
-      expect(mainEl?.className).toContain("md:max-w-[768px]");
+      const centerColumn = page.querySelector(".md\\:max-w-\\[768px\\]");
+      expect(centerColumn).toBeInTheDocument();
+      expect(centerColumn?.className).toContain("md:shrink-0");
     });
 
-    it("お気に入りリストのラッパーにmd:mx-autoが適用される", () => {
+    it("三カラムレイアウトにmd:flexが適用される", () => {
       render(<FavoritesPage />);
 
       const page = screen.getByTestId("favorites-page");
-      const mainEl = page.querySelector("main");
-      expect(mainEl?.className).toContain("md:mx-auto");
+      const flexWrapper = page.querySelector(".md\\:flex");
+      expect(flexWrapper).toBeInTheDocument();
     });
 
-    it("ローディング状態でもmd:max-w-[768px] md:mx-autoが適用される", () => {
+    it("ローディング状態でもmd:max-w-[768px]が適用される", () => {
       mockUseFavorites.mockReturnValue({
         favorites: [],
         isLoading: true,
@@ -312,12 +313,11 @@ describe("FavoritesPage", () => {
       render(<FavoritesPage />);
 
       const page = screen.getByTestId("favorites-page");
-      const mainEl = page.querySelector("main");
-      expect(mainEl?.className).toContain("md:max-w-[768px]");
-      expect(mainEl?.className).toContain("md:mx-auto");
+      const centerColumn = page.querySelector(".md\\:max-w-\\[768px\\]");
+      expect(centerColumn).toBeInTheDocument();
     });
 
-    it("エラー状態でもmd:max-w-[768px] md:mx-autoが適用される", () => {
+    it("エラー状態でもmd:max-w-[768px]が適用される", () => {
       mockUseFavorites.mockReturnValue({
         favorites: [],
         isLoading: false,
@@ -329,12 +329,11 @@ describe("FavoritesPage", () => {
       render(<FavoritesPage />);
 
       const page = screen.getByTestId("favorites-page");
-      const mainEl = page.querySelector("main");
-      expect(mainEl?.className).toContain("md:max-w-[768px]");
-      expect(mainEl?.className).toContain("md:mx-auto");
+      const centerColumn = page.querySelector(".md\\:max-w-\\[768px\\]");
+      expect(centerColumn).toBeInTheDocument();
     });
 
-    it("空状態でもmd:max-w-[768px] md:mx-autoが適用される", () => {
+    it("空状態でもmd:max-w-[768px]が適用される", () => {
       mockUseFavorites.mockReturnValue({
         favorites: [],
         isLoading: false,
@@ -346,9 +345,8 @@ describe("FavoritesPage", () => {
       render(<FavoritesPage />);
 
       const page = screen.getByTestId("favorites-page");
-      const mainEl = page.querySelector("main");
-      expect(mainEl?.className).toContain("md:max-w-[768px]");
-      expect(mainEl?.className).toContain("md:mx-auto");
+      const centerColumn = page.querySelector(".md\\:max-w-\\[768px\\]");
+      expect(centerColumn).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/(main)/favorites/page.tsx
+++ b/apps/web/src/app/(main)/favorites/page.tsx
@@ -74,7 +74,7 @@ export default function FavoritesPage() {
         />
 
         {/* 中央コンテンツ */}
-        <div className="w-full md:max-w-[768px] md:shrink-0 pb-8 px-4">
+        <div className="w-full md:max-w-[768px] md:shrink-0 md:h-screen md:overflow-y-auto pb-8 px-4">
           {/* AC-2: ヘッダー（スクロールで動く） */}
           <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
             <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>

--- a/apps/web/src/app/(main)/favorites/page.tsx
+++ b/apps/web/src/app/(main)/favorites/page.tsx
@@ -41,70 +41,54 @@ import { SkeletonLoader } from "./_components/SkeletonLoader";
 export default function FavoritesPage() {
   const { favorites, isLoading, error, removeFavorite, refresh } = useFavorites();
 
-  // AC-6: ローディング状態
+  // 状態に応じたコンテンツとカウントを決定
+  let content: React.ReactNode;
+  let count: string;
+
   if (isLoading) {
-    return (
-      <div data-testid="favorites-page" className="min-h-screen bg-gray-50">
-        <main className="pb-8 px-4 md:max-w-[768px] md:mx-auto">
-          {/* ヘッダー */}
-          <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
-            <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>
-            <span className="text-sm text-gray-400">0件</span>
-          </div>
-          <SkeletonLoader />
-        </main>
-      </div>
+    content = <SkeletonLoader />;
+    count = "0件";
+  } else if (error) {
+    content = <ErrorState onRetry={() => void refresh()} />;
+    count = "0件";
+  } else if (favorites.length === 0) {
+    content = <EmptyState />;
+    count = "0件";
+  } else {
+    content = (
+      <FavoriteList
+        favorites={favorites}
+        onRemove={(articleId) => void removeFavorite(articleId)}
+      />
     );
+    count = `${String(favorites.length)}件`;
   }
 
-  // AC-5: エラー状態
-  if (error) {
-    return (
-      <div data-testid="favorites-page" className="min-h-screen bg-gray-50">
-        <main className="pb-8 px-4 md:max-w-[768px] md:mx-auto">
-          {/* ヘッダー */}
-          <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
-            <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>
-            <span className="text-sm text-gray-400">0件</span>
-          </div>
-          <ErrorState onRetry={() => void refresh()} />
-        </main>
-      </div>
-    );
-  }
-
-  // AC-4: 空状態
-  if (favorites.length === 0) {
-    return (
-      <div data-testid="favorites-page" className="min-h-screen bg-gray-50">
-        <main className="pb-8 px-4 md:max-w-[768px] md:mx-auto">
-          {/* ヘッダー */}
-          <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
-            <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>
-            <span className="text-sm text-gray-400">0件</span>
-          </div>
-          <EmptyState />
-        </main>
-      </div>
-    );
-  }
-
-  // AC-2, AC-8: 通常表示
   return (
     <div data-testid="favorites-page" className="min-h-screen bg-gray-50">
-      <main className="pb-8 px-4 md:max-w-[768px] md:mx-auto">
-        {/* AC-2: ヘッダー（スクロールで動く） */}
-        <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
-          <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>
-          <span className="text-sm text-gray-400">{favorites.length}件</span>
+      <div className="md:flex">
+        {/* 左サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100"
+          style={{ boxShadow: "inset -1px 0 3px rgba(0,0,0,0.06)" }}
+        />
+
+        {/* 中央コンテンツ */}
+        <div className="w-full md:max-w-[768px] md:shrink-0 pb-8 px-4">
+          {/* AC-2: ヘッダー（スクロールで動く） */}
+          <div className="flex items-center justify-between py-4 pl-12 md:pl-4">
+            <h1 className="text-lg font-semibold text-gray-800">お気に入り</h1>
+            <span className="text-sm text-gray-400">{count}</span>
+          </div>
+          {content}
         </div>
 
-        {/* AC-8: お気に入りリスト */}
-        <FavoriteList
-          favorites={favorites}
-          onRemove={(articleId) => void removeFavorite(articleId)}
+        {/* 右サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100"
+          style={{ boxShadow: "inset 1px 0 3px rgba(0,0,0,0.06)" }}
         />
-      </main>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(main)/history/page.tsx
+++ b/apps/web/src/app/(main)/history/page.tsx
@@ -26,24 +26,43 @@ export default function HistoryPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* ヘッダー（AC-1, AC-5: 固定しない） */}
-      <div className="p-4">
-        <h1 className="text-lg font-semibold text-gray-800">閲覧履歴</h1>
-        <p className="text-sm text-gray-400">{String(history.length)}件</p>
-      </div>
+      <div className="md:flex">
+        {/* 左サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100"
+          style={{ boxShadow: "inset -1px 0 3px rgba(0,0,0,0.06)" }}
+        />
 
-      {/* 履歴一覧（AC-2） */}
-      <div className="space-y-3 px-4 pb-4">
-        {history.length === 0 ? (
-          <div className="flex flex-col items-center justify-center p-8 text-center">
-            <p className="text-gray-400">まだ閲覧履歴がありません</p>
-            <p className="text-sm text-gray-400 mt-1">記事を閲覧すると、ここに履歴が表示されます</p>
+        {/* 中央コンテンツ */}
+        <div className="w-full md:max-w-[768px] md:shrink-0">
+          {/* ヘッダー（AC-1, AC-5: 固定しない） */}
+          <div className="p-4 pl-16 md:pl-4">
+            <h1 className="text-lg font-semibold text-gray-800">閲覧履歴</h1>
+            <p className="text-sm text-gray-400">{String(history.length)}件</p>
           </div>
-        ) : (
-          history.map((entry) => (
-            <HistoryCard key={`${entry.scpNumber}-${entry.viewedAt}`} entry={entry} />
-          ))
-        )}
+
+          {/* 履歴一覧（AC-2） */}
+          <div className="space-y-3 px-4 pb-4">
+            {history.length === 0 ? (
+              <div className="flex flex-col items-center justify-center p-8 text-center">
+                <p className="text-gray-400">まだ閲覧履歴がありません</p>
+                <p className="text-sm text-gray-400 mt-1">
+                  記事を閲覧すると、ここに履歴が表示されます
+                </p>
+              </div>
+            ) : (
+              history.map((entry) => (
+                <HistoryCard key={`${entry.scpNumber}-${entry.viewedAt}`} entry={entry} />
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* 右サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100"
+          style={{ boxShadow: "inset 1px 0 3px rgba(0,0,0,0.06)" }}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/history/page.tsx
+++ b/apps/web/src/app/(main)/history/page.tsx
@@ -34,7 +34,7 @@ export default function HistoryPage() {
         />
 
         {/* 中央コンテンツ */}
-        <div className="w-full md:max-w-[768px] md:shrink-0">
+        <div className="w-full md:max-w-[768px] md:shrink-0 md:h-screen md:overflow-y-auto">
           {/* ヘッダー（AC-1, AC-5: 固定しない） */}
           <div className="p-4 pl-16 md:pl-4">
             <h1 className="text-lg font-semibold text-gray-800">閲覧履歴</h1>

--- a/apps/web/src/app/(viewer)/article/[articleId]/_components/ArticlePageContent.tsx
+++ b/apps/web/src/app/(viewer)/article/[articleId]/_components/ArticlePageContent.tsx
@@ -58,22 +58,46 @@ export function ArticlePageContent({ articleId }: ArticlePageContentProps) {
   }, []);
 
   return (
-    <div className="relative flex flex-col h-screen overflow-hidden" data-testid="article-page">
-      <div
-        ref={containerRef}
-        data-testid="article-webview"
-        className={cn("relative w-full flex-1 min-h-0")}
-      >
-        <iframe
-          src={iframeSrc}
-          className="w-full h-full border-0"
-          title="SCP記事"
-          sandbox="allow-scripts allow-same-origin allow-popups"
-          onLoad={handleIframeLoad}
+    <div
+      className="relative flex flex-col h-screen overflow-hidden md:h-auto md:overflow-visible"
+      data-testid="article-page"
+    >
+      <div className="md:flex md:min-h-[calc(100vh-56px)]">
+        {/* 左サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100 md:sticky md:top-14 md:h-[calc(100vh-56px)] md:self-start"
+          style={{ boxShadow: "inset -1px 0 3px rgba(0,0,0,0.06)" }}
+        />
+
+        {/* 中央コンテンツ */}
+        <div
+          className={cn(
+            "w-full md:max-w-[768px] md:shrink-0 relative flex flex-col flex-1 min-h-0 md:flex-none"
+          )}
+        >
+          <div
+            ref={containerRef}
+            data-testid="article-webview"
+            className={cn("relative w-full flex-1 min-h-0")}
+          >
+            <iframe
+              src={iframeSrc}
+              className="w-full h-full border-0"
+              title="SCP記事"
+              sandbox="allow-scripts allow-same-origin allow-popups"
+              onLoad={handleIframeLoad}
+            />
+          </div>
+          <AttributionFooter articleId={articleId} authorName={authorName} />
+          <FloatingFavoriteButton articleId={articleId} />
+        </div>
+
+        {/* 右サイドパネル */}
+        <div
+          className="hidden md:block flex-1 bg-gray-100 md:sticky md:top-14 md:h-[calc(100vh-56px)] md:self-start"
+          style={{ boxShadow: "inset 1px 0 3px rgba(0,0,0,0.06)" }}
         />
       </div>
-      <AttributionFooter articleId={articleId} authorName={authorName} />
-      <FloatingFavoriteButton articleId={articleId} />
     </div>
   );
 }

--- a/apps/web/src/app/(viewer)/layout.tsx
+++ b/apps/web/src/app/(viewer)/layout.tsx
@@ -1,5 +1,6 @@
 import { DrawerProvider, Drawer } from "@/shared/components/ui/Drawer";
 import { MenuButton } from "@/shared/components/ui/MenuButton";
+import { GlobalHeader } from "@/shared/components/ui/GlobalHeader";
 
 export default function ViewerLayout({
   children,
@@ -8,9 +9,10 @@ export default function ViewerLayout({
 }>) {
   return (
     <DrawerProvider>
+      <GlobalHeader />
       <MenuButton />
       <Drawer />
-      {children}
+      <div className="md:pt-14">{children}</div>
     </DrawerProvider>
   );
 }


### PR DESCRIPTION
## Summary
This PR implements a three-column layout for desktop views across multiple pages and refactors the page structure to support this new design pattern. The changes introduce symmetric left and right sidebar panels on desktop while maintaining responsive mobile layouts.

## Key Changes

- **Three-column layout implementation**: Added left and right sidebar panels (`flex-1 bg-gray-100`) to Favorites, History, and Article pages for desktop views, with the main content centered in a fixed-width column (`md:max-w-[768px] md:shrink-0`)

- **Favorites page refactoring**: 
  - Consolidated multiple conditional returns into a single render path with state-based content determination
  - Moved from `<main>` element to a flex-based layout structure
  - Simplified logic by determining `content` and `count` variables upfront

- **Article page layout update**:
  - Wrapped iframe and footer components in the center column
  - Added sticky positioning to sidebar panels on desktop
  - Changed from `h-screen overflow-hidden` to responsive `md:h-auto md:overflow-visible`

- **History page layout update**:
  - Applied three-column layout pattern consistently
  - Adjusted padding (`pl-16 md:pl-4`) to account for mobile navigation

- **Viewer layout enhancement**:
  - Added `GlobalHeader` component to the layout
  - Added `md:pt-14` padding to children to account for fixed header on desktop

- **Test updates**: Updated test selectors and assertions to match new DOM structure (targeting `.md:max-w-[768px]` instead of `main` element)

## Implementation Details

- Sidebar panels use `inset` box-shadow for subtle visual separation: `inset -1px 0 3px rgba(0,0,0,0.06)` (left) and `inset 1px 0 3px rgba(0,0,0,0.06)` (right)
- Desktop sidebars are hidden on mobile (`hidden md:block`) and use `flex-1` to fill available space
- Center columns maintain consistent `md:max-w-[768px]` width constraint across all pages
- Responsive behavior preserved: mobile uses full width, desktop uses centered three-column layout

https://claude.ai/code/session_017eFyYgoB1VK6fYwPXis77K