### PR TITLE
Refactor empty states and simplify sidebar styling

### DIFF
--- a/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
+++ b/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
@@ -179,6 +179,22 @@ describe("FavoritesPage", () => {
         screen.getByText("気に入った記事を保存して、いつでも読み返せます")
       ).toBeInTheDocument();
     });
+
+    it("「記事を探す」ボタンが表示される", () => {
+      render(<FavoritesPage />);
+
+      expect(screen.getByRole("button", { name: /記事を探す/ })).toBeInTheDocument();
+    });
+
+    it("ボタンタップで/recommendに遷移する", async () => {
+      const user = userEvent.setup();
+      render(<FavoritesPage />);
+
+      const button = screen.getByRole("button", { name: /記事を探す/ });
+      await user.click(button);
+
+      expect(mockPush).toHaveBeenCalledWith("/recommend");
+    });
   });
 
   describe("AC-5: エラー状態", () => {

--- a/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
+++ b/apps/web/src/app/(main)/favorites/__dev__/page.test.tsx
@@ -172,20 +172,12 @@ describe("FavoritesPage", () => {
       expect(screen.getByText("まだお気に入りがありません")).toBeInTheDocument();
     });
 
-    it("「記事を探す」ボタンが表示される", () => {
+    it("補足メッセージが表示される", () => {
       render(<FavoritesPage />);
 
-      expect(screen.getByRole("button", { name: /記事を探す/ })).toBeInTheDocument();
-    });
-
-    it("ボタンタップで/recommendに遷移する", async () => {
-      const user = userEvent.setup();
-      render(<FavoritesPage />);
-
-      const button = screen.getByRole("button", { name: /記事を探す/ });
-      await user.click(button);
-
-      expect(mockPush).toHaveBeenCalledWith("/recommend");
+      expect(
+        screen.getByText("気に入った記事を保存して、いつでも読み返せます")
+      ).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/app/(main)/favorites/_components/EmptyState/index.tsx
+++ b/apps/web/src/app/(main)/favorites/_components/EmptyState/index.tsx
@@ -3,19 +3,37 @@
  * @description お気に入り0件時の空状態表示
  * @see specs/006-frontend/006-03-favorites/006-03-01.md AC-4
  */
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/shared/components/ui/Button";
+
 /**
  * 空状態コンポーネント
  *
  * AC-4:
  * - EmptyStateコンポーネントが表示される
  * - 「まだお気に入りがありません」メッセージが表示される
+ * - 「記事を探す」ボタンが表示される
+ * - ボタンタップで `/recommend` に遷移する
  */
 export function EmptyState() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/recommend");
+  };
+
   return (
     <div data-testid="empty-state" className="bg-white rounded-xl shadow-sm p-8 text-center">
       {/* メッセージ */}
       <p className="text-gray-500">まだお気に入りがありません</p>
       <p className="text-sm text-gray-400 mt-2">気に入った記事を保存して、いつでも読み返せます</p>
+
+      {/* 記事を探すボタン */}
+      <Button onClick={handleClick} className="mt-4">
+        記事を探す
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/app/(main)/favorites/_components/EmptyState/index.tsx
+++ b/apps/web/src/app/(main)/favorites/_components/EmptyState/index.tsx
@@ -3,48 +3,19 @@
  * @description お気に入り0件時の空状態表示
  * @see specs/006-frontend/006-03-favorites/006-03-01.md AC-4
  */
-"use client";
-
-import { useRouter } from "next/navigation";
-import { Button } from "@/shared/components/ui/Button";
-import { Icon } from "@/shared/components/ui/Icon";
-
 /**
  * 空状態コンポーネント
  *
  * AC-4:
  * - EmptyStateコンポーネントが表示される
  * - 「まだお気に入りがありません」メッセージが表示される
- * - 「記事を探す」ボタンが表示される
- * - ボタンタップで `/recommend` に遷移する
  */
 export function EmptyState() {
-  const router = useRouter();
-
-  const handleClick = () => {
-    router.push("/recommend");
-  };
-
   return (
-    <div
-      data-testid="empty-state"
-      className="flex flex-col items-center justify-center gap-4 py-16 px-6 text-center"
-    >
-      {/* アイコン */}
-      <div className="text-gray-300">
-        <Icon name="heart" size={48} />
-      </div>
-
+    <div data-testid="empty-state" className="bg-white rounded-xl shadow-sm p-8 text-center">
       {/* メッセージ */}
-      <div className="space-y-2">
-        <p className="text-gray-500">まだお気に入りがありません</p>
-        <p className="text-sm text-gray-400">気に入った記事を保存して、いつでも読み返せます</p>
-      </div>
-
-      {/* 記事を探すボタン */}
-      <Button onClick={handleClick} className="mt-2">
-        記事を探す
-      </Button>
+      <p className="text-gray-500">まだお気に入りがありません</p>
+      <p className="text-sm text-gray-400 mt-2">気に入った記事を保存して、いつでも読み返せます</p>
     </div>
   );
 }

--- a/apps/web/src/app/(main)/favorites/page.tsx
+++ b/apps/web/src/app/(main)/favorites/page.tsx
@@ -68,10 +68,7 @@ export default function FavoritesPage() {
     <div data-testid="favorites-page" className="min-h-screen bg-gray-50">
       <div className="md:flex">
         {/* 左サイドパネル */}
-        <div
-          className="hidden md:block flex-1 bg-gray-100"
-          style={{ boxShadow: "inset -1px 0 3px rgba(0,0,0,0.06)" }}
-        />
+        <div className="hidden md:block flex-1" />
 
         {/* 中央コンテンツ */}
         <div className="w-full md:max-w-[768px] md:shrink-0 md:h-screen md:overflow-y-auto pb-8 px-4">
@@ -84,10 +81,7 @@ export default function FavoritesPage() {
         </div>
 
         {/* 右サイドパネル */}
-        <div
-          className="hidden md:block flex-1 bg-gray-100"
-          style={{ boxShadow: "inset 1px 0 3px rgba(0,0,0,0.06)" }}
-        />
+        <div className="hidden md:block flex-1" />
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/history/_components/HistoryCard/index.tsx
+++ b/apps/web/src/app/(main)/history/_components/HistoryCard/index.tsx
@@ -69,7 +69,7 @@ export function HistoryCard({ entry }: HistoryCardProps) {
   return (
     <Link
       href={`/article/${encodeURIComponent(entry.scpNumber)}`}
-      className="block bg-white rounded-xl shadow-sm p-4 transition-transform active:scale-[0.98]"
+      className="block bg-white rounded-xl shadow-sm p-4 transition-all duration-200 active:scale-[0.98] md:hover:-translate-y-0.5 md:hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]"
       data-testid="history-card"
     >
       <div className="flex items-start gap-3">

--- a/apps/web/src/app/(main)/history/page.tsx
+++ b/apps/web/src/app/(main)/history/page.tsx
@@ -28,10 +28,7 @@ export default function HistoryPage() {
     <div className="min-h-screen bg-gray-50">
       <div className="md:flex">
         {/* 左サイドパネル */}
-        <div
-          className="hidden md:block flex-1 bg-gray-100"
-          style={{ boxShadow: "inset -1px 0 3px rgba(0,0,0,0.06)" }}
-        />
+        <div className="hidden md:block flex-1" />
 
         {/* 中央コンテンツ */}
         <div className="w-full md:max-w-[768px] md:shrink-0 md:h-screen md:overflow-y-auto">
@@ -44,9 +41,9 @@ export default function HistoryPage() {
           {/* 履歴一覧（AC-2） */}
           <div className="space-y-3 px-4 pb-4">
             {history.length === 0 ? (
-              <div className="flex flex-col items-center justify-center p-8 text-center">
-                <p className="text-gray-400">まだ閲覧履歴がありません</p>
-                <p className="text-sm text-gray-400 mt-1">
+              <div className="bg-white rounded-xl shadow-sm p-8 text-center">
+                <p className="text-gray-500">まだ閲覧履歴がありません</p>
+                <p className="text-sm text-gray-400 mt-2">
                   記事を閲覧すると、ここに履歴が表示されます
                 </p>
               </div>
@@ -59,10 +56,7 @@ export default function HistoryPage() {
         </div>
 
         {/* 右サイドパネル */}
-        <div
-          className="hidden md:block flex-1 bg-gray-100"
-          style={{ boxShadow: "inset 1px 0 3px rgba(0,0,0,0.06)" }}
-        />
+        <div className="hidden md:block flex-1" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
This PR refactors the empty state components for consistency and simplifies the sidebar panel styling across the favorites and history pages. It also enhances the history card with improved hover effects on desktop.

## Key Changes

- **EmptyState Component Refactoring**
  - Removed client-side dependencies (`useRouter`, `Button`, `Icon` components)
  - Removed the "記事を探す" (Find Articles) button and navigation to `/recommend`
  - Simplified layout to focus on the empty state message only
  - Updated styling to use consistent card design (`bg-white rounded-xl shadow-sm p-8`)

- **Sidebar Panel Simplification**
  - Removed background color (`bg-gray-100`) from left and right sidebar panels in both favorites and history pages
  - Removed inset box-shadow styling from sidebars
  - Panels now serve as simple flex containers without visual styling

- **History Page Empty State**
  - Updated empty state styling to match the new card design pattern
  - Changed text color from `text-gray-400` to `text-gray-500` for better contrast
  - Adjusted spacing with `mt-2` instead of `mt-1`

- **HistoryCard Enhancement**
  - Added smooth transition effects (`transition-all duration-200`)
  - Added desktop hover state with subtle lift effect (`md:hover:-translate-y-0.5`)
  - Added enhanced shadow on hover (`md:hover:shadow-[0_4px_12px_rgba(0,0,0,0.1)]`)

## Implementation Details

The changes align with a cleaner, more minimal design approach:
- Empty states now use a consistent card-based layout across the application
- Sidebar panels are simplified to be transparent containers, allowing the background to show through
- Interactive elements (history cards) now have improved visual feedback on desktop devices
- Removed unnecessary client-side logic from the favorites empty state component

https://claude.ai/code/session_01PoojTPBg525LNcf8tL3J6G