### PR TITLE
perf(infra): pin Vercel Functions to hnd1 to resolve issue #340 cross-region latency

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,5 +3,6 @@
   "framework": "nextjs",
   "installCommand": "pnpm install",
   "buildCommand": "pnpm --filter web build",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "regions": ["hnd1"]
 }

--- a/docs/operations/slow-query-optimization.md
+++ b/docs/operations/slow-query-optimization.md
@@ -323,3 +323,36 @@ A案で79%改善したが目標100msに対して3.9〜6.0倍の乖離が残存�
 - **アラート解消**:
   - embedding: **解消済み**（33.5ms、目標100ms達成）
   - unexplored_tags: **未解消**（Phase D後の実測値なし、196ms → 50ms以下期待）
+
+### [2026-05-07] 対応 #3: API ネットワークレイテンシ最適化（Vercel Functions リージョン統一）
+
+スロークエリ範囲外だが、issue #340（APIレスポンスタイム劣化）の根本対応として記録する。
+
+#### 検出
+
+- issue #340 で 2026-04-19 以降、`POST /api/recommend` warm 中央値 1,500〜1,800ms（閾値 1,000ms）、`GET /api/favorites` warm 中央値 850〜940ms（閾値 500ms）が継続 FAIL。
+- DB 単体クエリ（embedding 33.5ms）は Phase B〜D で最適化済み、PR #342 で API 層のキャッシュ導入・getProfile 重複除去・keep-warm 導入も完了済み。それでも閾値超過が続いていた。
+
+#### 分析
+
+- `apps/web/vercel.json` に `regions` 指定がなく、Vercel Functions が **デフォルトで `iad1`（us-east-1, バージニア）** にデプロイされていた。
+- Upstash Redis は `docs/operations/setup-upstash-redis.md` で `ap-northeast-1`（東京）推奨、Supabase プロジェクトも日本向けサービスのため東京リージョン想定。
+- iad1 ↔ 東京の RTT は約 150〜180 ms/往復。`/recommend` の 4〜10 RTT、`/favorites` の 3〜4 RTT が累積し、計測値とほぼ整合。
+
+#### Why
+
+DB 最適化と API 層の最適化を尽くしても閾値超過が継続している以上、**残存する支配要因はネットワークレイテンシのみ**であり、Vercel Function のリージョンを Supabase/Upstash と同一リージョンに統一することで解消可能と判断した。
+
+#### How
+
+`apps/web/vercel.json` に `"regions": ["hnd1"]` を追加（Tokyo）。
+
+#### 期待効果
+
+- `/recommend` warm 中央値: 1,500〜1,800ms → **300〜600ms**（-1,000ms 程度）
+- `/favorites` warm 中央値: 850〜940ms → **150〜400ms**（-500ms 程度）
+- 018-03-01 AC2 を PASS に到達させる。
+
+#### 注意
+
+Supabase プロジェクトのリージョンが東京以外（例: シンガポール `sin1`、ソウル `icn1`、フランクフルト `fra1` 等）の場合は、`vercel.json` の `regions` 値もそれに合わせること。Supabase Dashboard → Settings → Infrastructure で確認可能。


### PR DESCRIPTION
## Summary

issue #340（API レスポンスタイム劣化）の継続FAILに対する **残存根本原因の対応**。

PR #342 で API 層キャッシュ・getProfile重複除去・keep-warm を実装した後も、warm 中央値が `/recommend` 1500-1800ms（閾値1000ms）/ `/favorites` 850-940ms（閾値500ms）と19日連続でFAILしていた。深掘り調査の結果、残存の支配要因は **Vercel Functions のリージョンミスマッチ** と判明。

### 原因
- `apps/web/vercel.json` に `regions` 指定がなく、Vercel Functions がデフォルトの **`iad1`（us-east-1, バージニア）** にデプロイされていた
- 一方 Upstash Redis は `docs/operations/setup-upstash-redis.md` で `ap-northeast-1`（東京）推奨と明記されており、Supabase も日本向けサービスのため東京想定
- iad1 ↔ 東京の RTT 約 150ms × DB往復 N回 が累積し、警告値に達していた（`/recommend` で 4〜10 RTT、`/favorites` で 3〜4 RTT）

### 修正
- `apps/web/vercel.json`: `"regions": ["hnd1"]` を追加（Tokyo に固定）
- `docs/operations/slow-query-optimization.md`: 対応 #3 として経緯と期待効果を追記

### 期待効果
- `/recommend` warm 中央値: 1,500〜1,800ms → **300〜600ms**
- `/favorites` warm 中央値: 850〜940ms → **150〜400ms**
- 018-03-01 AC2 PASS、issue #340 の自動継続劣化レポート停止

## ⚠️ マージ前の必須確認事項

**Supabase Dashboard → Settings → Infrastructure で実際のプロジェクトリージョンを確認してください。**

| Supabase リージョン | Vercel `regions` 値 |
|---|---|
| `ap-northeast-1`（Tokyo） | `hnd1` ← 現在の設定 |
| `ap-southeast-1`（Singapore） | `sin1` |
| `ap-northeast-2`（Seoul） | `icn1` |
| `eu-central-1`（Frankfurt） | `fra1` |
| `us-east-1`（N. Virginia） | `iad1`（変更不要） |

東京以外の場合は値を変更してください。Upstash Redis のリージョンも同じ値に揃えると最良です。

## Vercel プラン制約
`hnd1` 単一リージョン指定なので Hobby プラン（1リージョンのみ）でも動作します。

## Test plan
- [ ] Supabase リージョンが `ap-northeast-1` であることを Dashboard で確認
- [ ] プレビューデプロイで `npx tsx scripts/check-api-performance.ts` を手動実行
- [ ] warm 中央値が `/recommend` ≤ 1,000ms、`/favorites` ≤ 500ms を満たすことを確認
- [ ] マージ後に `gh workflow run performance-check.yml` で本番計測ジョブを起動
- [ ] 3日連続で warm PASS を確認できたら issue #340 を close

## 後続検討（本PR スコープ外）
効果検証後にさらなる改善余地があれば以下を別PRで対応:
- `packages/shared/src/recommendation/serendipity.ts:168-209` の段階的緩和ループの並列化（serendipity分岐時のスパイク抑制）
- Vercel Function の `memory: 1024` 設定によるコールドスタート緩和

https://claude.ai/code/session_01UwGX6Uzuh9sHFjHgy2jmhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwGX6Uzuh9sHFjHgy2jmhD)_