### PR TITLE
fix(e2e): 本番DB状態に依存しないAPI直叩きセットアップと毎日定期実行を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,10 @@ jobs:
           fi
 
       # --- E2E実行（リモートURLが取得できた場合のみ） ---
+      # E2E setup helper (apps/web/e2e/lib/api-setup.ts) は PLAYWRIGHT_API_URL が
+      # 未指定の場合 ${PLAYWRIGHT_BASE_URL}/api にフォールバックする。
+      # PR(preview)/push(prod) いずれでもテスト対象URLと同じホストの API を叩くため、
+      # ここでは PLAYWRIGHT_API_URL を明示しない（preview の /api を確実に使うため）。
       - name: Run Critical E2E Tests
         if: steps.e2e_target.outputs.skip != 'true'
         run: pnpm --filter web test:e2e --grep @critical --reporter=list,blob

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -1,0 +1,183 @@
+# 毎日定期 E2E テスト
+#
+# main マージ時の E2E（ci.yml）に加え、本番URL対向のE2Eを毎日1回実行して
+# 本番デプロイ後の劣化（Vercel/Supabase/Upstash等の外部要因含む）を翌マージを
+# 待たずに検知する。
+#
+# 失敗時は health-check.yml と同じパターンで type:ops + e2e:failure ラベル付きの
+# Issue を自動起票（同ラベルの Open Issue があれば追記、なければ新規作成）。
+#
+# Required Secrets:
+#   secrets.PRODUCTION_URL  本番Web URL（例: https://scpicks.app）
+#                           E2E setup helper が ${PRODUCTION_URL}/api を API ベースURLとして使う
+
+name: E2E Scheduled
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # JST 03:00（UTC 18:00）
+  workflow_dispatch: {} # 手動テスト用
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: E2E Tests (Scheduled)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Browsers
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Run Critical E2E Tests
+        id: e2e_critical
+        run: pnpm --filter web test:e2e --grep @critical --reporter=list,blob
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PRODUCTION_URL }}
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report
+
+      - name: Run Non-Critical E2E Tests
+        id: e2e_non_critical
+        if: always()
+        run: pnpm --filter web test:e2e --grep-invert @critical --reporter=list,blob
+        continue-on-error: true
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PRODUCTION_URL }}
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report
+
+      - name: Merge E2E Reports
+        if: always()
+        run: |
+          if find apps/web/blob-report -name '*.zip' 2>/dev/null | grep -q .; then
+            pnpm --filter web exec playwright merge-reports --reporter=html ./blob-report
+          else
+            echo "::warning::No blob report files found, skipping merge"
+          fi
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-scheduled-${{ github.run_id }}
+          path: apps/web/playwright-report/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Test Results (Traces)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-scheduled-${{ github.run_id }}
+          path: apps/web/e2e/test-results/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Handle E2E failure
+        if: failure() && steps.e2e_critical.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const timestamp = new Date().toISOString();
+
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'type:ops,e2e:failure',
+              state: 'open',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 1
+            });
+
+            const body = [
+              `## 定期 E2E 失敗レポート`,
+              ``,
+              `| 項目 | 値 |`,
+              `| --- | --- |`,
+              `| 検知時刻 | ${timestamp} |`,
+              `| 対象URL | ${{ secrets.PRODUCTION_URL }} |`,
+              `| ワークフロー実行 | ${runUrl} |`,
+              ``,
+              `### 確認手順`,
+              `1. 上記ワークフロー実行ページから Playwright Report (artifact) をダウンロード`,
+              `2. 失敗したテストの screenshot / trace を確認`,
+              `3. 本番アプリ・API・Supabase・Upstash の状態を確認`,
+              `4. 一過性なら手動再実行（workflow_dispatch）、再現するなら fix PR を作成`,
+            ].join('\n');
+
+            if (existingIssues.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssues[0].number,
+                body
+              });
+              core.info(`Issue #${existingIssues[0].number} に継続失敗コメントを追加`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[E2E Scheduled] 本番E2E失敗 - ${timestamp.slice(0, 10)}`,
+                body,
+                labels: ['type:ops', 'e2e:failure']
+              });
+              core.info('新規 e2e:failure Issue を作成');
+            }
+
+      - name: Handle E2E recovery
+        if: success() && steps.e2e_critical.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const timestamp = new Date().toISOString();
+
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'type:ops,e2e:failure',
+              state: 'open',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 1
+            });
+
+            if (existingIssues.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssues[0].number,
+                body: [
+                  `## 復旧確認`,
+                  ``,
+                  `定期E2Eが正常に戻りました。`,
+                  ``,
+                  `| 項目 | 値 |`,
+                  `| --- | --- |`,
+                  `| 復旧時刻 | ${timestamp} |`,
+                  `| ワークフロー実行 | ${runUrl} |`,
+                  ``,
+                  `> このIssueは手動でクローズしてください。`,
+                ].join('\n')
+              });
+              core.info(`Issue #${existingIssues[0].number} に復旧コメントを追加`);
+            }

--- a/apps/web/e2e/lib/api-setup.ts
+++ b/apps/web/e2e/lib/api-setup.ts
@@ -1,0 +1,91 @@
+/**
+ * E2Eテスト用 API セットアップヘルパー
+ *
+ * 本番URL対向のE2Eで mock を使わず、実バックエンドの冪等エンドポイントを叩いて
+ * テスト visitor の状態（オンボーディング完了 / お気に入り 1件以上）を確実に整える。
+ *
+ * - POST /visitors           : 既存なら 200, 新規なら 201（冪等）
+ * - POST /onboarding/select  : 再オンボーディング時は履歴/推薦ログ/フィードバックを clear（冪等）
+ * - POST /favorites/:id      : 既登録なら 200, 新規なら 201（冪等）
+ */
+import type { Page } from "@playwright/test";
+
+const DEFAULT_LOCAL_API_URL = "http://localhost:3001";
+
+/**
+ * 利用する API ベースURL を解決する
+ *
+ * 優先順位:
+ * 1. PLAYWRIGHT_API_URL（CI で明示指定）
+ * 2. PLAYWRIGHT_BASE_URL + "/api"（Vercel デプロイは /api 配下に Hono を mount）
+ * 3. http://localhost:3001（ローカルの api-server スタンドアロン）
+ */
+export function getApiBaseUrl(): string {
+  const explicit = process.env.PLAYWRIGHT_API_URL;
+  if (explicit) return explicit.replace(/\/$/, "");
+
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL;
+  if (baseUrl) return `${baseUrl.replace(/\/$/, "")}/api`;
+
+  return DEFAULT_LOCAL_API_URL;
+}
+
+async function postJson(page: Page, url: string, body: unknown, context: string): Promise<unknown> {
+  const res = await page.request.post(url, { data: body });
+  if (!res.ok()) {
+    const text = await res.text();
+    throw new Error(
+      `[E2E setup] ${context} failed: ${String(res.status())} ${url} body=${text.slice(0, 300)}`
+    );
+  }
+  // 204 No Content など本文が無いケースがある
+  const ct = res.headers()["content-type"] ?? "";
+  if (ct.includes("application/json")) {
+    return (await res.json()) as unknown;
+  }
+  return null;
+}
+
+/**
+ * テスト visitor がオンボーディング完了状態になるよう本番DBを冪等にセットアップする。
+ *
+ * 1. POST /visitors          で visitor を確実に作成
+ * 2. POST /onboarding/select で profile.onboarding_completed_at と
+ *    preference_embedding を生成（既存の場合は履歴 clear + 再構築）
+ *
+ * 完了後は /recommend が API error 400 (OnboardingRequired) を返さなくなる。
+ */
+export async function prepareOnboardedVisitor(
+  page: Page,
+  visitorId: string,
+  packType: "classic" | "horror" | "scifi" | "heartwarming" | "mystery" | "jp" = "horror"
+): Promise<void> {
+  const apiBase = getApiBaseUrl();
+  await postJson(page, `${apiBase}/visitors`, { visitorId }, "register visitor");
+  await postJson(
+    page,
+    `${apiBase}/onboarding/select`,
+    { visitorId, packTypes: [packType] },
+    "select starter pack"
+  );
+}
+
+/**
+ * テスト visitor のお気に入りに 1 件以上の記事を確実に追加する。
+ *
+ * 既にお気に入り済みなら 200 が返り、状態は維持される（冪等）。
+ * 完了後は /favorites の取得結果が 1 件以上になり favorite-list が描画される。
+ */
+export async function ensureFavorite(
+  page: Page,
+  visitorId: string,
+  articleId: string
+): Promise<void> {
+  const apiBase = getApiBaseUrl();
+  await postJson(
+    page,
+    `${apiBase}/favorites/${articleId}`,
+    { visitorId },
+    `add favorite ${articleId}`
+  );
+}

--- a/apps/web/e2e/lib/setup.ts
+++ b/apps/web/e2e/lib/setup.ts
@@ -1,8 +1,10 @@
 /**
  * E2Eテスト用セットアップヘルパー
  *
- * Playwrightテストの前提条件（localStorage設定）を管理
- * APIは本番対向で実行（モックなし）
+ * Playwrightテストの前提条件（localStorage + 本番API状態）を管理。
+ * mock は使わず、本番URL対向でも決定論的に動くよう、
+ * 冪等な API（POST /visitors, /onboarding/select, /favorites/:id）で
+ * テスト visitor の DB 状態を毎回整える。
  */
 import type { Page } from "@playwright/test";
 import {
@@ -11,6 +13,10 @@ import {
   mockHistoryEntries,
   STORAGE_KEYS,
 } from "./mock-data";
+import { ensureFavorite, prepareOnboardedVisitor } from "./api-setup";
+
+/** お気に入りテスト用に常時1件以上を保証する記事（horror パックの seed 記事） */
+const FAVORITE_SEED_ARTICLE_ID = "scp-087";
 
 /**
  * 閲覧履歴のlocalStorageをシードする
@@ -58,22 +64,36 @@ export async function seedVisitorId(page: Page): Promise<void> {
 
 /**
  * 推薦画面テスト用のフルセットアップ
+ *
+ * 本番DB上に固定 test visitor を冪等にオンボーディング済み状態で配置し、
+ * フロント側の localStorage にも同じ visitorId を seed する。
  */
 export async function setupRecommendTest(page: Page): Promise<void> {
+  await prepareOnboardedVisitor(page, mockVisitorOnboarded.visitorId);
   await seedOnboardingCompleted(page);
 }
 
 /**
  * お気に入り画面テスト用のフルセットアップ
+ *
+ * オンボーディング済み visitor の状態に加え、お気に入りが
+ * 必ず 1 件以上存在する状態を冪等に作る。
  */
 export async function setupFavoritesTest(page: Page): Promise<void> {
+  await prepareOnboardedVisitor(page, mockVisitorOnboarded.visitorId);
+  await ensureFavorite(page, mockVisitorOnboarded.visitorId, FAVORITE_SEED_ARTICLE_ID);
   await seedOnboardingCompleted(page);
 }
 
 /**
  * 閲覧履歴画面テスト用のフルセットアップ
+ *
+ * 履歴は localStorage に保持されるため API セットアップは不要だが、
+ * /history への遷移後に visitor ベースの API（お気に入りバッジ等）が
+ * 失敗しないよう、visitor だけは登録しておく。
  */
 export async function setupHistoryTest(page: Page): Promise<void> {
+  await prepareOnboardedVisitor(page, mockVisitorOnboarded.visitorId);
   await seedOnboardingCompleted(page);
   await seedHistory(page);
 }

--- a/apps/web/src/app/(main)/recommend/_hooks/useInfiniteArticles.ts
+++ b/apps/web/src/app/(main)/recommend/_hooks/useInfiniteArticles.ts
@@ -21,6 +21,40 @@ const DEFAULT_PREFETCH_THRESHOLD = 3;
 const FETCH_TIMEOUT_MS = 10_000;
 
 /**
+ * RFC 7807 Problem Details の type が onboarding-required の場合に true を返す
+ */
+function isOnboardingRequiredProblem(json: unknown): boolean {
+  if (typeof json !== "object" || json === null) return false;
+  const type = (json as { type?: unknown }).type;
+  return typeof type === "string" && type.endsWith("/onboarding-required");
+}
+
+/**
+ * 推薦API失敗時のエラーオブジェクトを生成する
+ *
+ * - 400 onboarding_required: 「オンボーディングが完了していません」と日本語で表現
+ * - その他: 「記事の取得に失敗しました」を表示し、status は内部エラーとしてのみ保持
+ */
+async function buildRecommendApiError(res: Response): Promise<Error> {
+  let body: unknown = null;
+  try {
+    body = await res.clone().json();
+  } catch {
+    // 本文が JSON でない場合は無視
+  }
+
+  if (res.status === 400 && isOnboardingRequiredProblem(body)) {
+    const err = new Error(
+      "オンボーディングが完了していません。再度オンボーディングをお試しください。"
+    );
+    err.name = "OnboardingRequiredError";
+    return err;
+  }
+
+  return new Error("記事の取得に失敗しました。時間をおいて再試行してください。");
+}
+
+/**
  * 有効なURLを持つ記事のみをフィルタする
  * 空文字列のURLは翻訳なしとみなし除外する
  */
@@ -91,7 +125,7 @@ export function useInfiniteArticles(
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- res.ok は実行時に false になる可能性がある
         if (!res.ok) {
-          throw new Error(`API error: ${String(res.status)}`);
+          throw await buildRecommendApiError(res);
         }
 
         const data = (await res.json()) as RecommendResponse;

--- a/apps/web/src/app/(main)/recommend/page.tsx
+++ b/apps/web/src/app/(main)/recommend/page.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useInfiniteArticles } from "./_hooks/useInfiniteArticles";
 import { useFeedback, calculateInterestLevel } from "./_hooks/useFeedback";
 import { useArticleFavorite } from "@/shared/hooks/useArticleFavorite";
@@ -42,8 +43,16 @@ import { SkeletonLoader } from "@/shared/components/ui/SkeletonLoader";
  * AC-10: prefers-reduced-motion対応
  */
 export default function RecommendPage() {
+  const router = useRouter();
   const { articles, currentIndex, isLoading, error, isEmpty, goToNext, refetch } =
     useInfiniteArticles();
+
+  // OnboardingRequired (400) は再試行しても解消しないため /onboarding に誘導する
+  useEffect(() => {
+    if (error?.name === "OnboardingRequiredError") {
+      router.replace("/onboarding");
+    }
+  }, [error, router]);
 
   const { recordNext, recordFavorite } = useFeedback();
   const currentArticle = articles[currentIndex] as (typeof articles)[number] | undefined;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,9 +86,10 @@ export default tseslint.config(
       "n/no-process-env": "off",
     },
   },
-  // Playwright設定ではprocess.env.CI参照が必須
+  // Playwright設定とE2Eテストヘルパーではprocess.env参照を許可
+  // (CI/PLAYWRIGHT_BASE_URL/PLAYWRIGHT_API_URL等の参照が必須)
   {
-    files: ["**/e2e/playwright.config.ts"],
+    files: ["**/e2e/playwright.config.ts", "**/e2e/lib/**/*.ts"],
     rules: {
       "n/no-process-env": "off",
       "no-console": "off",


### PR DESCRIPTION
## 概要

E2Eレポート（https://sn005.github.io/recommend-scp/e2e-report/）で失敗していた `@critical` テストを修正し、main マージ時の E2E に加えて **毎日 1 回・本番URL対向**の定期実行を追加する。

## 失敗していたテストと根本原因

| Spec | 失敗テスト | 症状 |
| --- | --- | --- |
| `recommend.spec.ts` | 推薦カード表示 / カード情報表示確認 / 記事詳細WebView表示 / お気に入りボタン動作 | `/recommend` が `API error: 400` を表示し `transition-card` が描画されず timeout |
| `favorites.spec.ts` | お気に入り一覧表示 | `favorite-list` が描画されず空状態（"0件"）が表示される |

**原因**: E2Eテストは本番URL対向で動くが、テスト visitor (`e2e00000-...-001`) を localStorage に seed するだけで本番DBには profile / preference_embedding が存在しない。4/25 の PR #342 (`61b4746`) で `RecommendService` が `onboarding_completed_at` と `preferenceEmbedding` の存在を要求するようになった結果、`OnboardingRequiredError` (400) が返るようになった。

## 修正方針: mock を使わず本物の本番パイプラインを検証

「mock に頼ると毎日定期実行の意味が薄れる」という観点から、Playwright の `request` コンテキストから**冪等な API を直接叩く**セットアップに統一:

```
[テスト前 — apps/web/e2e/lib/api-setup.ts]
  POST /visitors                  ← 既存なら 200 / 新規なら 201（冪等）
  POST /onboarding/select         ← 再オンボーディングで履歴 clear + profile 再構築（冪等）
  POST /favorites/scp-087         ← 既登録なら 200（冪等）— favorites テストのみ

[localStorage seed — 既存ロジック]
  visitorId, onboardingCompleted=true

[ページ遷移]
  /recommend / /favorites / /history → 本番 API が本物のデータを返す
```

これで本番DBに固定 test visitor が**1 体だけ**常駐し、毎テスト前に冪等にオンボーディング状態を整え直すため決定論的に通る。`clearHistoryIfReOnboarding` で履歴・推薦ログ・フィードバックは毎回 reset されるためデータも汚染しない。

## アプリ側の UX バグも同時修正

レポートのスクショに見えていた `API error: 400` の生表示を撤廃:

- `useInfiniteArticles.ts`: RFC 7807 の `type` を見て `OnboardingRequiredError` を識別 / それ以外は日本語メッセージに置換
- `recommend/page.tsx`: `OnboardingRequiredError` 検知時に `router.replace("/onboarding")` で自動誘導

## 毎日定期実行（新規 e2e-scheduled.yml）

- cron: `0 18 * * *` (UTC) = JST 03:00
- 対向URL: `secrets.PRODUCTION_URL`
- 失敗時: `health-check.yml` と同じパターンで `type:ops, e2e:failure` ラベル付きの Issue を自動起票（既存 Open Issue があれば追記）
- 成功時: `e2e:failure` ラベルの open Issue があれば復旧コメントを追加
- レポートは artifact `playwright-report-scheduled-{run_id}` として 14日保持。GitHub Pages の `e2e-report/` は main push 時のレポートを保持する想定で**上書きしない**

## 主な変更ファイル

| ファイル | 変更内容 |
| --- | --- |
| `apps/web/e2e/lib/api-setup.ts` (新規) | `prepareOnboardedVisitor` / `ensureFavorite` / `getApiBaseUrl` |
| `apps/web/e2e/lib/setup.ts` | 各 setup 関数の先頭で API セットアップを実行 |
| `apps/web/src/app/(main)/recommend/_hooks/useInfiniteArticles.ts` | RFC 7807 検知 + 日本語エラーメッセージ |
| `apps/web/src/app/(main)/recommend/page.tsx` | `OnboardingRequiredError` で /onboarding にリダイレクト |
| `.github/workflows/e2e-scheduled.yml` (新規) | 毎日定期 E2E + 失敗時 Issue 起票 |
| `.github/workflows/ci.yml` | API URL 派生方針コメント追記 |
| `eslint.config.mjs` | `e2e/lib/**/*.ts` で `process.env` 参照を許可 |

## Test plan

- [x] ローカル: `pnpm --filter web type-check` — 全 pass
- [x] ローカル: `pnpm --filter web test` — 78 ファイル / 1300 テスト pass
- [x] ローカル: `pnpm lint` `pnpm format:check` — clean
- [ ] PR: CI の `e2e:` ジョブが Vercel preview 対向で全 critical 通ること
- [ ] マージ後: `ci.yml` の本番URL対向で全 critical 通ること（GitHub Pages の `e2e-report/` が緑になる）
- [ ] 翌 JST 03:00: `e2e-scheduled.yml` が初回実行され artifact が生成されること
- [ ] 手動: GitHub UI から `e2e-scheduled.yml` を `workflow_dispatch` で起動して即時動作確認
- [ ] 失敗系: `PRODUCTION_URL` を一時的に不正値に差し替えて手動実行し、`type:ops, e2e:failure` Issue が起票されることを確認（要事後 close）

## スコープ外

- バックエンド `RecommendService` の挙動変更（onboarding 未完了時に空配列を返す等）は実施しない。挙動として正しく、フロント側で誘導するのが妥当
- 本番DBへのテスト visitor 手動シードは不要（API 呼び出しが冪等で自動作成されるため）

https://claude.ai/code/session_01MwBBdgM82GCBo4T3JnTYSB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwBBdgM82GCBo4T3JnTYSB)_