### PR TITLE
fix(e2e): お気に入りボタンの testid を PC 版にも付与し可視要素優先に

### DIFF
--- a/apps/web/e2e/lib/__dev__/step-executor.test.ts
+++ b/apps/web/e2e/lib/__dev__/step-executor.test.ts
@@ -29,6 +29,7 @@ function createMockPage() {
     fill: mockFill,
     waitFor: mockWaitFor,
     first: vi.fn().mockReturnThis(),
+    filter: vi.fn().mockReturnThis(),
   };
   const mockGetByTestId = vi.fn().mockReturnValue(mockLocator);
   const mockGoto = vi.fn().mockResolvedValue(undefined);

--- a/apps/web/e2e/lib/step-executor.ts
+++ b/apps/web/e2e/lib/step-executor.ts
@@ -18,24 +18,27 @@ async function executeStep(page: Page, step: StepAction): Promise<void> {
       await page.goto(step.url);
       break;
     case "click":
-      await page.getByTestId(step.testId).first().click();
+      await page.getByTestId(step.testId).filter({ visible: true }).first().click();
       break;
     case "fill":
-      await page.getByTestId(step.testId).first().fill(step.value);
+      await page.getByTestId(step.testId).filter({ visible: true }).first().fill(step.value);
       break;
     case "waitFor":
       await page
         .getByTestId(step.testId)
+        .filter({ visible: true })
         .first()
         .waitFor({
           timeout: step.timeout ?? 5000,
         });
       break;
     case "assertVisible":
-      await expect(page.getByTestId(step.testId).first()).toBeVisible();
+      await expect(page.getByTestId(step.testId).filter({ visible: true }).first()).toBeVisible();
       break;
     case "assertText":
-      await expect(page.getByTestId(step.testId).first()).toHaveText(step.text);
+      await expect(page.getByTestId(step.testId).filter({ visible: true }).first()).toHaveText(
+        step.text
+      );
       break;
     case "assertUrl":
       await expect(page).toHaveURL(new RegExp(step.pattern));

--- a/apps/web/src/app/(main)/recommend/_components/PCActionButtons/PCActionButtons.tsx
+++ b/apps/web/src/app/(main)/recommend/_components/PCActionButtons/PCActionButtons.tsx
@@ -16,6 +16,7 @@ export function PCActionButtons({ isFavorited, onFavorite, onNext }: Props) {
         type="button"
         onClick={onFavorite}
         aria-label={isFavorited ? "お気に入りから削除" : "お気に入りに追加"}
+        data-testid="floating-favorite-button"
         className={`
           inline-flex items-center gap-2 px-7 py-3 rounded-xl text-[15px] font-medium border shadow-lg
           ${


### PR DESCRIPTION
## Summary

Issue #345 の定期 E2E 失敗（`推薦画面 › お気に入りボタン動作 @critical` / TC-006-02-004）を修正します。

### 根本原因

PR #321「Implement PC responsive layout with 3-column design and action buttons」で PC レイアウトを `PCActionButtons` に分離した際、

- `FloatingUI` (=`PillNav`) は `md:hidden` でモバイル専用 → `data-testid="floating-favorite-button"` を保持
- `PCActionButtons` は `hidden md:flex` で PC 専用 → testid **未付与**

E2E は `Desktop Chrome` (1280×720) で実行されるため、PillNav が `display:none` で隠され、`getByTestId('floating-favorite-button').first().waitFor()` が15秒タイムアウトしていました。

```
35 × locator resolved to hidden <button ... data-testid="floating-favorite-button">
```

### 変更内容

- `PCActionButtons.tsx`: 「お気に入り」ボタンに `data-testid="floating-favorite-button"` を付与
- `step-executor.ts`: `click` / `fill` / `waitFor` / `assertVisible` / `assertText` で `.first()` の前に `.filter({ visible: true })` を挟み、Desktop / Mobile 両方のビューポートで可視要素を優先選択
- `step-executor.test.ts`: モックロケータに `filter` メソッドを追加

PillNav 側の testid は維持（既存単体テスト互換 / 将来のモバイル E2E 用）。

## Test plan

- [x] `pnpm --filter web type-check` 通過
- [x] `pnpm test` 通過（1300/1300）
- [x] step-executor 単体テスト通過（filter 追加対応含む）
- [ ] CI で `推薦画面 › お気に入りボタン動作 @critical` が緑になること
- [ ] 本番デプロイ後、定期 E2E ワークフローを workflow_dispatch で再実行して全 critical テストが通ること

Closes #345


---
_Generated by [Claude Code](https://claude.ai/code/session_01U2Kms1N97tuNLLbZvh2fsG)_